### PR TITLE
Outputting Exception from charts as a logging error message.  Fixes #33

### DIFF
--- a/reckoner/config.py
+++ b/reckoner/config.py
@@ -32,7 +32,7 @@ class Config(object):
     Arguments:
     - None
 
-    Atrributes:
+    Attributes:
     - home (String): Defaults to "$HOME/.helm" but is overridden by
       environment variable $HELM_HOME
     - archive (String): Interpolated path for the helm archive

--- a/reckoner/course.py
+++ b/reckoner/course.py
@@ -106,7 +106,7 @@ class Course(object):
         try:
             iter(charts_to_install)
         except TypeError:
-            charts_to_install = (charts_to_install)
+            charts_to_install = charts_to_install
 
         for chart in self.charts:
             if chart.release_name in charts_to_install:
@@ -119,6 +119,8 @@ class Course(object):
             except (Exception, ReckonerCommandException), e:
                 if type(e) == ReckonerCommandException:
                     logging.error(e.stderr)
+                if type(e) == Exception:
+                    logging.error(e)
                 logging.error('Helm upgrade failed. Rolling back {}'.format(chart.release_name))
                 logging.debug(traceback.format_exc())
                 chart.rollback

--- a/tests/test_reckoner.py
+++ b/tests/test_reckoner.py
@@ -343,7 +343,7 @@ class TestChart(TestBase):
         for chart in self.charts:
             self.subprocess_mock.assert_called()
             os.environ[test_environ_var_name] = test_environ_var
-            assert chart.install(test_namespace) == None
+            assert chart.install(test_namespace) is None
             logging.debug(chart)
 
             # TODO - we really need to refactor this to be better about testing in the same layer


### PR DESCRIPTION
Other small fixes to spelling, formatting, etc.

New output:
```
✓± reckoner  plot course.yaml --heading metrics-server
2019-01-07 16:17:35 root[25426]     INFO Installing metrics-server
2019-01-07 16:17:36 root[25426]    ERROR Missing requirement environment variable: METRIC_RESOLUTION
2019-01-07 16:17:36 root[25426]    ERROR Helm upgrade failed. Rolling back metrics-server
2019-01-07 16:17:36 root[25426]    ERROR ERROR: Some charts failed to install and were rolled back
2019-01-07 16:17:36 root[25426]    ERROR  - metrics-server
```