### PR TITLE
Reintroduce Helm dependency update before chart install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.11.0]
+
+### Added
+- Ensure chart dependencies are up to date with `helm dependency update` before installing it
+
 ## [0.10.3]
 
 ### Fixed

--- a/reckoner/chart.py
+++ b/reckoner/chart.py
@@ -167,7 +167,6 @@ class Chart(object):
         logging.debug("Updating chart dependencies: {}".format(self.chart_path))
         if os.path.exists(self.chart_path):
             try:
-                # TODO This is actually broken - not implemented (even before refactor)
                 r = self.helm.dependency_update(self.chart_path)
             except ReckonerCommandException, e:
                 logging.warn("Unable to update chart dependencies: {}".format(e.stderr))
@@ -196,11 +195,9 @@ class Chart(object):
         # TODO: Improve error handling of a repository installation
         self.repository.install(self.name, self.version)
         self.chart_path = self.repository.chart_path
-        # Update the helm dependencies
 
-        if self.repository.git is None:
-            # TODO this is broken
-            self.update_dependencies()
+        # Update the helm dependencies
+        self.update_dependencies()
 
         # Build the args for the chart installation
         # And add any extra arguments

--- a/reckoner/helm/client.py
+++ b/reckoner/helm/client.py
@@ -90,7 +90,8 @@ class HelmClient(object):
         )
 
     def dependency_update(self, chart_path):
-        raise NotImplementedError('Sorry this feature has not yet been implemented.')
+        """Function to update chart dependencies"""
+        return self.execute('dependency', ['update', chart_path], filter_non_global_flags=True)
 
     def repo_update(self):
         """Function to update all the repositories"""

--- a/reckoner/helm/tests/test_client.py
+++ b/reckoner/helm/tests/test_client.py
@@ -119,8 +119,8 @@ incubator       https://kubernetes-charts-incubator.storage.googleapis.com
         assert without_install.command.command == 'install'
 
     def test_dependency_update(self):
-        with self.assertRaises(NotImplementedError):
-            HelmClient(provider=self.dummy_provider).dependency_update('')
+        HelmClient(provider=self.dummy_provider).dependency_update('chart_path')
+        self.dummy_provider.execute.assert_called_once
 
     def test_repo_update(self):
         HelmClient(provider=self.dummy_provider).repo_update()

--- a/reckoner/meta.py
+++ b/reckoner/meta.py
@@ -14,5 +14,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.10.3'
+__version__ = '0.11.0'
 __author__ = 'ReactiveOps, Inc.'


### PR DESCRIPTION
To install cert-manager from their GitHub repository, we need to pull dependencies from their chart repo.

I re-implemented the `helm dependency update` call before installing the chart.

Try with
```yaml
minimum_versions:
  helm: 2.12.1
  reckoner: 0.10.2
charts:
  cert-manager:
    repository:
      git: https://github.com/jetstack/cert-manager
      path: contrib/charts
    version: release-0.5
    namespace: kube-system
``` 