### PR TITLE
WIP Reckoner 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] UNRELEASED
+
+### Fixed
+- `version` command is fixed
+- `generate` command is removed (was broken for several versions)
+
+### Changes
+- Adjusted schema to support `set` option for charts
+  - This will translate all elements into `--set key=value` for the helm run
+  - Current behavior actually does this for `values: {}`
+  - All `values:` uses will warn that future versions will be type strong
+
 ## [0.11.1]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [0.13.0] UNRELEASED
+## [1.0.0-rc1]
 
 ### Fixed
 - `version` command is fixed
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - This will translate all elements into `--set key=value` for the helm run
   - Current behavior actually does this for `values: {}`
   - All `values:` uses will warn that future versions will be type strong
+- More testing for CLI contract options
 
 ## [0.12.0]
 

--- a/reckoner/chart.py
+++ b/reckoner/chart.py
@@ -221,10 +221,10 @@ class Chart(object):
             [logging.warning(msg) for msg in self._deprecation_messages]
 
     def build_helm_arguments_for_chart(self):
-        '''
+        """
         This method builds all the arguments we'll pass along to the helm
         client once we need to run the install
-        '''
+        """
 
         # Set Default args (release name and chart path)
         self.args = [
@@ -268,19 +268,19 @@ class Chart(object):
         self.build_set_string_arguments()
 
     def _merge_set_and_values(self):
-        '''
+        """
         This is a temporary method that will be gone once the values: vs set:
         debacle has been resolved. (See https://github.com/reactiveops/reckoner/issues/7)
 
         NOTE ONLY RUN THIS ONCE BECAUSE IT'S NOT IDEMPOTENT
-        '''
+        """
         if self._hack_set_values_already_merged:
             raise StandardError('This method cannot be called twice. '
                                 'If you are seeing this please open an '
                                 'issue in github.')
 
         def merge_dicts(values, sets):
-            '''This does a dict merge and prefers "sets" values'''
+            """This does a dict merge and prefers "sets" values"""
             new_dict = values.copy()
             new_dict.update(sets)
             return new_dict
@@ -292,12 +292,12 @@ class Chart(object):
         self._hack_set_values_already_merged = True
 
     def build_temp_values_files(self):
-        '''
+        """
         This method builds temporary files based on the values: settings
         provided in the course.yml. This effectively keeps type persistence
         between the course.yml and what is passed to helm. If you use set:
         value arguments then you can lose types like int, float and true/false
-        '''
+        """
         if self.values:
             self._deprecation_messages = [
                 "DEPRECATION NOTICE: The behavior of `values: {}` will change in "
@@ -317,33 +317,33 @@ class Chart(object):
             )
 
     def build_files_list(self):
-        '''
+        """
         This method builds the files list for all
         files specified in the course.yml
-        '''
+        """
         for values_file in self.files:
             self.args.append("-f={}".format(values_file))
 
     def build_set_string_arguments(self):
-        '''
+        """
         Builder for "set-string" arguments in helm command line
         This method specifically modifies the Chart object to
         prepare the command line arguments.
 
         Note running this multiple times will provide duplicate arguments
-        '''
+        """
         for key, value in self.values_strings.iteritems():
             for k, v in self._format_set(key, value):
                 self.args.append("--set-string={}={}".format(k, v))
 
     def build_set_arguments(self):
-        '''
+        """
         Builder for "set" arguments in helm command line
         This method specifically modifies the Chart object to
         prepare the command line arguments.
 
         Note running this multiple times will provide duplicate arguments
-        '''
+        """
         for key, value in self.set_values.iteritems():
             for k, v in self._format_set(key, value):
                 self.args.append("--set={}={}".format(k, v))

--- a/reckoner/chart.py
+++ b/reckoner/chart.py
@@ -67,6 +67,8 @@ class Chart(object):
         if value_strings != {}:
             del(self._chart['values-strings'])
 
+        self._deprecation_messages = []
+
     @property
     def helm_args(self):
         """ Returns list of extra options/args for the helm command """
@@ -299,21 +301,10 @@ class Chart(object):
         value arguments then you can lose types like int, float and true/false
         """
         if self.values:
-            self._deprecation_messages = [
-                "DEPRECATION NOTICE: The behavior of `values: {}` will change in "
-                "v0.14+. Currently values: are set as --set arguments for the "
-                "helm command. This behavior makes all `values: {}` you set in "
-                "the course.yml lose type fidelity, true becomes string(\"true\") "
-                "and all int values become a string of the integer. See "
-                "https://github.com/reactiveops/reckoner/issues/7 for details. ",
-                "To avoid any unexpected changes in behavior, change your "
-                "`values: {}` configuration to `set-values: {}`."
-            ]
-        for value in self.values.keys():
-            logging.debug(
-                "Settings value({}) as a --set argument. "
-                "Type of the value may not be what you expect. "
-                "This is a deprecation method.".format(value)
+            self._deprecation_messages.append(
+                "DEPRECATION NOTICE: Change 'values: {}' to 'set-values: {}' "
+                "to keep consistent behavior beyond v1.1+. Details: "
+                "https://github.com/reactiveops/reckoner/issues/7"
             )
 
     def build_files_list(self):

--- a/reckoner/chart.py
+++ b/reckoner/chart.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 import logging
-import subprocess
 import os
 
 from collections import OrderedDict
@@ -47,8 +46,8 @@ class Chart(object):
     - namespace
 
     Returns:
-    - Instance of Response() is truthy where Reponse.exitcode == 0
-    - Instance of Response() is falsey where Reponse.exitcode != 0
+    - Instance of Response() is truthy where Response.exitcode == 0
+    - Instance of Response() is falsey where Response.exitcode != 0
     """
 
     def __init__(self, chart, helm):
@@ -58,6 +57,7 @@ class Chart(object):
         self._chart = chart[self._release_name]
         self._repository = Repository(self._chart.get('repository', default_repository), self.helm)
         self._chart['values'] = self._chart.get('values', {})
+        self._chart['sets'] = self._chart.get('sets', {})
 
         self._namespace = self._chart.get('namespace')
         self._context = self._chart.get('context')
@@ -66,6 +66,13 @@ class Chart(object):
 
         if value_strings != {}:
             del(self._chart['values-strings'])
+
+    @property
+    def helm_args(self):
+        """ Returns list of extra options/args for the helm command """
+        if self.config.helm_args is not None:
+            return self.config.helm_args
+        return []
 
     @property
     def release_name(self):
@@ -80,6 +87,17 @@ class Chart(object):
         Returns chart name of course chart
         """
         return self._chart.get('chart', self._release_name)
+
+    @property
+    def debug_args(self):
+        """ Returns list of Helm debug arguments """
+
+        if self.config.dryrun:
+            return ['--dry-run', '--debug']
+        if self.config.debug:
+            return ['--debug']
+
+        return []
 
     @property
     def files(self):
@@ -97,32 +115,10 @@ class Chart(object):
         """ Namespace to install the course chart """
         return self._context
 
-    def __check_env_vars(self):
-        """
-        accepts list of args
-        if any of those appear to be env vars
-        and are missing from the environment
-        an exception is raised
-        """
-        try:
-            self.args = [Template(arg).substitute(os.environ) for arg in self.args]
-        except KeyError, e:
-            raise Exception("Missing requirement environment variable: {}".format(e.args[0]))
-
     @property
     def repository(self):
         """ Repository object parsed from course chart """
         return self._repository
-
-    def __getattr__(self, key):
-        return self._chart.get(key)
-
-    def __str__(self):
-        return str(dict(self._chart))
-
-    def __get_hook(self, hook_type):
-        if self.hooks is not None:
-            return self.hooks.get(hook_type)
 
     def pre_install_hook(self):
         self.run_hook('pre_install')
@@ -132,13 +128,13 @@ class Chart(object):
 
     def run_hook(self, hook_type):
         """ Hook Type. Runs the commands defined by the hook """
-        coms = self.__get_hook(hook_type)
-        if coms is None:
-            return coms
-        if type(coms) == str:
-            coms = [coms]
+        commands = self.__get_hook(hook_type)
+        if commands is None:
+            return commands
+        if type(commands) == str:
+            commands = [commands]
 
-        for com in coms:
+        for com in commands:
             if self.config.local_development or self.config.dryrun:
                 logging.info("Hook not run due to --dry-run: {}".format(com))
                 continue
@@ -164,12 +160,13 @@ class Chart(object):
         """ Update the course chart dependencies """
         if self.config.local_development or self.config.dryrun:
             return True
-        logging.debug("Updating chart dependencies: {}".format(self.chart_path))
-        if os.path.exists(self.chart_path):
+        logging.debug("Updating chart dependencies: {}".format(self.repository.chart_path))
+        if os.path.exists(self.repository.chart_path):
             try:
-                r = self.helm.dependency_update(self.chart_path)
-            except ReckonerCommandException, e:
-                logging.warn("Unable to update chart dependencies: {}".format(e.stderr))
+                response = self.helm.dependency_update(self.repository.chart_path)
+                logging.debug(response.stderr + "\n" + response.stdout)
+            except ReckonerCommandException, error:
+                logging.warn("Unable to update chart dependencies: {}".format(error.stderr))
 
     def install(self, namespace=None, context=None):
         """
@@ -178,9 +175,6 @@ class Chart(object):
 
         Arguments:
         - namespace (string). Passed in but will be overridden by Chart().namespace if set
-
-        Returns:
-        - Bool
         """
 
         # Set the namespace
@@ -191,63 +185,162 @@ class Chart(object):
         if self.context is None:
             self._context = context
 
+        # Fire the pre_install_hook
         self.pre_install_hook()
+
         # TODO: Improve error handling of a repository installation
+        #       Thoughts here, perhaps it would be better to install the
+        #       repositories *before* trying to install the chart. This
+        #       way we could find out earlier our course is wrong.
         self.repository.install(self.name, self.version)
-        self.chart_path = self.repository.chart_path
 
         # Update the helm dependencies
         self.update_dependencies()
 
         # Build the args for the chart installation
         # And add any extra arguments
+        self.build_helm_arguments_for_chart()
 
-        self.args = ['{}'.format(self._release_name), self.chart_path, ]
+        # Check and Error if we're missing required env vars
+        self.__check_env_vars()
+
+        # Perform the upgrade with the arguments
+        try:
+            # Try to run helm upgrade
+            helm_command_response = self.helm.upgrade(self.args)
+            # Log the stdout response in info
+            logging.info(helm_command_response.stdout)
+        except HelmClientException, error:
+            logging.error(error)
+            return
+
+        # Fire the post_install_hook
+        self.post_install_hook()
+
+    def build_helm_arguments_for_chart(self):
+        '''
+        This method builds all the arguments we'll pass along to the helm
+        client once we need to run the install
+        '''
+
+        # Set Default args (release name and chart path)
+        self.args = [
+            '{}'.format(self._release_name),
+            self.repository.chart_path,
+        ]
+
+        # Add namespace to args
         self.args.append('--namespace={}'.format(self.namespace))
+
+        # Add kubecfg context
         if self.context is not None:
             self.args.append('--kube-context={}'.format(self.context))
+
+        # Add debug arguments
         self.args.extend(self.debug_args)
+
+        # Add the version arguments
         if self.version:
             self.args.append('--version={}'.format(self.version))
-        for file in self.files:
-            self.args.append("-f={}".format(file))
 
-        for key, value in self.values.iteritems():
-            for k, v in self._format_set(key, value):
-                self.args.append("--set={}={}".format(k, v))
+        # HACK: This is in place until we can fully deprecate the usage of set
+        #       in place of values. Currently values: gets translated into
+        #       --set commands to the helm command line run. This should be
+        #       changed so that set: goes to command line args and values: goes
+        #       to temporary values files, to keep strong types in yaml.
+        #       This will go away once we fully change the functionality of
+        #       values: vs sets: settings in course.yml
+        self._merge_set_and_values()
 
+        # Build the list of existing yaml files to use for the helm command
+        self.build_files_list()
+
+        # Build the file arguments from the `values: {}` in course.yml
+        self.build_temp_values_files()
+
+        # Build the list of --set arguments
+        self.build_set_arguments()
+
+        # Build the list of --set-string arguments
+        self.build_set_string_arguments()
+
+    def _merge_set_and_values(self):
+        '''
+        This is a temporary method that will be gone once the values: vs set:
+        debacle has been resolved. (See https://github.com/reactiveops/reckoner/issues/7)
+
+        NOTE ONLY RUN THIS ONCE BECAUSE IT'S NOT IDEMPOTENT
+        '''
+        if self.__already_merged:
+            raise StandardError('This method cannot be called twice. '
+                                'If you are seeing this please open an '
+                                'issue in github.')
+
+        def merge_dicts(values, sets):
+            '''This does a dict merge and prefers "sets" values'''
+            new_dict = values.copy()
+            new_dict.update(sets)
+            return new_dict
+
+        logging.debug('Merging values: into sets: - sets: take precedence.')
+        logging.debug('Original value of sets: {}'.format(self.sets))
+        self.sets = merge_dicts(self.values, self.sets)
+        logging.debug('New value of sets: {}'.format(self.sets))
+        self.__already_merged = True
+
+    def build_temp_values_files(self):
+        '''
+        This method builds temporary files based on the values: settings
+        provided in the course.yml. This effectively keeps type persistence
+        between the course.yml and what is passed to helm. If you use set:
+        value arguments then you can lose types like int, float and true/false
+        '''
+        logging.warning(
+            "DEPRECATION NOTICE: The behavior of `values: {}` will change in "
+            "v0.14+. Currently values: are set as --set arguments for the "
+            "helm command. This behavior makes all values: you set in the "
+            "course.yml lose type fidelity, true becomes string(\"true\") "
+            "and all int values become a string of the integer. See "
+            "https://github.com/reactiveops/reckoner/issues/7 for details."
+        )
+        for value in self.values.keys():
+            logging.debug(
+                "Settings value({}) as a --set argument. "
+                "Type of the value may not be what you expect. "
+                "This is a deprecation method.".format(value)
+            )
+
+    def build_files_list(self):
+        '''
+        This method builds the files list for all
+        files specified in the course.yml
+        '''
+        for values_file in self.files:
+            self.args.append("-f={}".format(values_file))
+
+    def build_set_string_arguments(self):
+        '''
+        Builder for "set-string" arguments in helm command line
+        This method specifically modifies the Chart object to
+        prepare the command line arguments.
+
+        Note running this multiple times will provide duplicate arguments
+        '''
         for key, value in self.values_strings.iteritems():
             for k, v in self._format_set(key, value):
                 self.args.append("--set-string={}={}".format(k, v))
 
-        self.__check_env_vars()
+    def build_set_arguments(self):
+        '''
+        Builder for "set" arguments in helm command line
+        This method specifically modifies the Chart object to
+        prepare the command line arguments.
 
-        try:
-            r = self.helm.upgrade(self.args)
-            logging.info(r.stdout)
-        except HelmClientException, e:
-            logging.error(e)
-            return
-
-        self.post_install_hook()
-
-    @property
-    def debug_args(self):
-        """ Returns list of Helm debug arguments """
-
-        if self.config.dryrun:
-            return ['--dry-run', '--debug']
-        if self.config.debug:
-            return ['--debug']
-
-        return []
-
-    @property
-    def helm_args(self):
-        """ Returns list of extra options/args for the helm command """
-        if self.config.helm_args is not None:
-            return self.config.helm_args
-        return []
+        Note running this multiple times will provide duplicate arguments
+        '''
+        for key, value in self.sets.iteritems():
+            for k, v in self._format_set(key, value):
+                self.args.append("--set={}={}".format(k, v))
 
     def _format_set(self, key, value):
         """
@@ -278,3 +371,25 @@ class Chart(object):
                     yield "{}[{}]".format(key, index), item
         else:
             yield key, value
+
+    def __getattr__(self, key):
+        return self._chart.get(key)
+
+    def __str__(self):
+        return str(dict(self._chart))
+
+    def __get_hook(self, hook_type):
+        if self.hooks is not None:
+            return self.hooks.get(hook_type)
+
+    def __check_env_vars(self):
+        """
+        accepts list of args
+        if any of those appear to be env vars
+        and are missing from the environment
+        an exception is raised
+        """
+        try:
+            self.args = [Template(arg).substitute(os.environ) for arg in self.args]
+        except KeyError, e:
+            raise Exception("Missing requirement environment variable: {}".format(e.args[0]))

--- a/reckoner/cli.py
+++ b/reckoner/cli.py
@@ -31,6 +31,9 @@ from meta import __version__
 @click.pass_context
 def cli(ctx, log_level, *args, **kwargs):
     coloredlogs.install(level=log_level)
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+        ctx.exit(1)
     pass
 
 

--- a/reckoner/cli.py
+++ b/reckoner/cli.py
@@ -55,18 +55,6 @@ def plot(ctx, file=None, dry_run=False, debug=False, only=None, helm_args=None, 
 
 
 @cli.command()
-@click.pass_context
-def generate(ctx):
-    """ Takes no arguments, outputs an example plan """
-    logging.info('Generating example course as course.yml')
-    src = pkg_resources.resource_string("reckoner", "example-course.yml")
-    logging.debug(src)
-    with open("./course.yml", "w") as course_file:
-        course_file.write(src)
-
-
-@cli.command()
-@click.pass_context
-def version(ctx):
+def version():
     """ Takes no arguments, outputs version info"""
-    print(reckoner.__version__)
+    print(__version__)

--- a/reckoner/config.py
+++ b/reckoner/config.py
@@ -16,11 +16,9 @@
 
 
 import os
-import sys
 import logging
 
-from command_line_caller import call
-from exception import ReckonerCommandException
+from .command_line_caller import call
 
 
 class Config(object):

--- a/reckoner/helm/client.py
+++ b/reckoner/helm/client.py
@@ -86,7 +86,7 @@ class HelmClient(object):
 
     def rollback(self, release):
         raise NotImplementedError(
-            '''This is known bad. If you see this error then you are likely implementing the solution :)'''
+            """This is known bad. If you see this error then you are likely implementing the solution :)"""
         )
 
     def dependency_update(self, chart_path):

--- a/reckoner/helm/client.py
+++ b/reckoner/helm/client.py
@@ -137,7 +137,7 @@ class HelmClient(object):
         get_ver = self.execute("version", arguments=['--short', kind], filter_non_global_flags=True)
         ver = self._find_version(get_ver.stdout)
 
-        if ver == None:
+        if ver is None:
             raise HelmClientException(
                 """Could not find version!! Could the helm response format have changed?
                 STDOUT: {}

--- a/reckoner/meta.py
+++ b/reckoner/meta.py
@@ -15,5 +15,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.13.0'
+__version__ = '1.0.0-rc1'
 __author__ = 'ReactiveOps, Inc.'

--- a/reckoner/meta.py
+++ b/reckoner/meta.py
@@ -14,5 +14,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.11.1'
+__version__ = '0.13.0'
 __author__ = 'ReactiveOps, Inc.'

--- a/reckoner/reckoner.py
+++ b/reckoner/reckoner.py
@@ -13,14 +13,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+'''Reckoner object'''
 
 import logging
 import sys
 
-from config import Config
-from course import Course
-from helm.client import HelmClient, HelmClientException
+from .config import Config
+from .course import Course
+from .helm.client import HelmClient, HelmClientException
 
 
 class Reckoner(object):

--- a/reckoner/reckoner.py
+++ b/reckoner/reckoner.py
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-'''Reckoner object'''
+"""Reckoner object"""
 
 import logging
 import sys

--- a/reckoner/tests/test_cli.py
+++ b/reckoner/tests/test_cli.py
@@ -35,7 +35,7 @@ class TestCli(unittest.TestCase):
         self.assertEqual(0, result.exit_code)
         self.assertNotEqual('', result.output)
 
-    def test_exits_without_subcommad(self):
+    def test_exits_without_subcommand(self):
         '''Assure we fail when run without subcommands and show some info'''
         runner = CliRunner()
         result = runner.invoke(cli.cli)

--- a/reckoner/tests/test_cli.py
+++ b/reckoner/tests/test_cli.py
@@ -1,10 +1,20 @@
+'''Testing of CLI commands in click, contract tests'''
+
 import unittest
-from reckoner import cli
+import mock
 from click.testing import CliRunner
+from reckoner import cli
 
 
 class TestCli(unittest.TestCase):
+    '''
+    Test all the contracts of the command line tool.
+    If something changes in here than you should consider that in your version
+    bumping scheme.
+    '''
+
     def test_version(self):
+        '''Assure version subcommand exists'''
         runner = CliRunner()
         result = runner.invoke(cli.version)
 
@@ -17,15 +27,33 @@ class TestCli(unittest.TestCase):
         self.assertNotEqual('', result.output)
 
     def test_supports_loglevel(self):
+        '''assure we have a global command for --log-level'''
         runner = CliRunner()
-        result = runner.invoke(cli.cli, args=['--log-level', 'DEBUG', 'version'])
+        result = runner.invoke(
+            cli.cli, args=['--log-level', 'DEBUG', 'version'])
 
         self.assertEqual(0, result.exit_code)
         self.assertNotEqual('', result.output)
 
-    def test_exits_without_subcmd(self):
+    def test_exits_without_subcommad(self):
+        '''Assure we fail when run without subcommands and show some info'''
         runner = CliRunner()
         result = runner.invoke(cli.cli)
 
         self.assertEqual(1, result.exit_code)
         self.assertNotEqual(u'', result.output)
+
+    @mock.patch('reckoner.cli.Reckoner', autospec=True)
+    def test_plot_exists(self, reckoner_mock):
+        '''Assure we have a plot command and it calls reckoner install'''
+        reckoner_instance = reckoner_mock()
+        reckoner_instance.install.side_effect = [None]
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            with open('nonexistant.file', 'w') as fake_file:
+                fake_file.write('')
+
+            result = runner.invoke(cli.plot, args=['nonexistant.file'])
+
+        self.assertEqual(0, result.exit_code, result.output)
+        reckoner_instance.install.assert_called_once()

--- a/reckoner/tests/test_cli.py
+++ b/reckoner/tests/test_cli.py
@@ -1,4 +1,4 @@
-'''Testing of CLI commands in click, contract tests'''
+"""Testing of CLI commands in click, contract tests"""
 
 import unittest
 import mock
@@ -7,14 +7,14 @@ from reckoner import cli
 
 
 class TestCli(unittest.TestCase):
-    '''
+    """
     Test all the contracts of the command line tool.
     If something changes in here than you should consider that in your version
     bumping scheme.
-    '''
+    """
 
     def test_version(self):
-        '''Assure version subcommand exists'''
+        """Assure version subcommand exists"""
         runner = CliRunner()
         result = runner.invoke(cli.version)
 
@@ -27,7 +27,7 @@ class TestCli(unittest.TestCase):
         self.assertNotEqual('', result.output)
 
     def test_supports_loglevel(self):
-        '''assure we have a global command for --log-level'''
+        """assure we have a global command for --log-level"""
         runner = CliRunner()
         result = runner.invoke(
             cli.cli, args=['--log-level', 'DEBUG', 'version'])
@@ -36,7 +36,7 @@ class TestCli(unittest.TestCase):
         self.assertNotEqual('', result.output)
 
     def test_exits_without_subcommand(self):
-        '''Assure we fail when run without subcommands and show some info'''
+        """Assure we fail when run without subcommands and show some info"""
         runner = CliRunner()
         result = runner.invoke(cli.cli)
 
@@ -45,7 +45,7 @@ class TestCli(unittest.TestCase):
 
     @mock.patch('reckoner.cli.Reckoner', autospec=True)
     def test_plot_exists(self, reckoner_mock):
-        '''Assure we have a plot command and it calls reckoner install'''
+        """Assure we have a plot command and it calls reckoner install"""
         reckoner_instance = reckoner_mock()
         reckoner_instance.install.side_effect = [None]
         runner = CliRunner()

--- a/reckoner/tests/test_cli.py
+++ b/reckoner/tests/test_cli.py
@@ -1,0 +1,31 @@
+import unittest
+from reckoner import cli
+from click.testing import CliRunner
+
+
+class TestCli(unittest.TestCase):
+    def test_version(self):
+        runner = CliRunner()
+        result = runner.invoke(cli.version)
+
+        self.assertEqual(0, result.exit_code)
+        self.assertNotEqual('', result.output)
+
+        result = runner.invoke(cli.cli, args=['--version'])
+
+        self.assertEqual(0, result.exit_code)
+        self.assertNotEqual('', result.output)
+
+    def test_supports_loglevel(self):
+        runner = CliRunner()
+        result = runner.invoke(cli.cli, args=['--log-level', 'DEBUG', 'version'])
+
+        self.assertEqual(0, result.exit_code)
+        self.assertNotEqual('', result.output)
+
+    def test_exits_without_subcmd(self):
+        runner = CliRunner()
+        result = runner.invoke(cli.cli)
+
+        self.assertEqual(1, result.exit_code)
+        self.assertNotEqual(u'', result.output)

--- a/tests/test_reckoner.py
+++ b/tests/test_reckoner.py
@@ -425,3 +425,5 @@ class TestConfig(TestBase):
         self.assertEqual(self.c1.__dict__, self.c2.__dict__)
         self.c1.test = 'value'
         self.assertEqual(self.c1.__dict__, self.c2.__dict__)
+        self.assertIs(self.c1.test, self.c2.test)
+        self.assertIsNot(self.c1, self.c2)

--- a/tests/test_reckoner.py
+++ b/tests/test_reckoner.py
@@ -351,7 +351,7 @@ class TestChart(TestBase):
                     '--install',
                     # '--namespace={}'.format(chart.namespace),
                     chart.release_name,
-                    chart.chart_path,
+                    chart.repository.chart_path,
                 ]
             )
             if chart.name == test_environ_var_chart:
@@ -364,7 +364,7 @@ class TestChart(TestBase):
                         '--recreate-pods',
                         '--install',
                         chart.release_name,
-                        chart.chart_path,
+                        chart.repository.chart_path,
                         '--namespace={}'.format(chart.namespace),
                         '--set={}={}'.format(test_environ_var_name, test_environ_var)]
                 )
@@ -377,7 +377,7 @@ class TestChart(TestBase):
                         '--recreate-pods',
                         '--install',
                         chart.release_name,
-                        chart.chart_path,
+                        chart.repository.chart_path,
                         '--namespace={}'.format(chart.namespace),
                         '--version=0.1.0',
                         '--set-string=string=string',

--- a/tests/test_reckoner.py
+++ b/tests/test_reckoner.py
@@ -19,8 +19,6 @@ import unittest
 import coloredlogs
 import logging
 import os
-import git
-import subprocess
 import shutil
 import mock
 import reckoner
@@ -30,9 +28,7 @@ from reckoner.reckoner import Reckoner
 from reckoner.config import Config
 from reckoner.course import Course
 from reckoner.repository import Repository
-from reckoner.exception import MinimumVersionException, ReckonerCommandException
 from reckoner.helm.client import HelmClient
-from reckoner.helm.cmd_response import HelmCmdResponse
 
 
 class TestBase(unittest.TestCase):
@@ -353,7 +349,7 @@ class TestChart(TestBase):
                     'upgrade',
                     '--recreate-pods',
                     '--install',
-                    #'--namespace={}'.format(chart.namespace),
+                    # '--namespace={}'.format(chart.namespace),
                     chart.release_name,
                     chart.chart_path,
                 ]


### PR DESCRIPTION
## This is still a work in progress

### Fixes
* `version` command works again
* Non-working `generate` subcommand is removed
* Added functionality to fail and display help when you just run `reckoner` with no subcommand
* Added tests to some of the contracts in the cli.py

### Changes
* Initial support for migration from `values: {}` to `sets: {}`. See #7 for details.