### PR TITLE
Release Candidate for 1.0.0 (RC1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-rc1]
+
+### Fixed
+- `version` command is fixed
+- `generate` command is removed (was broken for several versions)
+
+### Changes
+- Adjusted schema to support `set` option for charts
+  - This will translate all elements into `--set key=value` for the helm run
+  - Current behavior actually does this for `values: {}`
+  - All `values:` uses will warn that future versions will be type strong
+- More testing for CLI contract options
+
+### Deprecation Notice
+In the future, the `values: {}` configuration of a chart will change it's
+behavior (see Issue #7). The current behavior translates any `values:{}` into
+`--set` for the command line helm. This makes certain object types lose their
+type fidelity. This means `true` becomes `string("true")` when pushed through
+`--set values=true`. To maintain the same behavior for your settings please
+change `values:{}` to `set-values:{}`. This behavior deprecaton will start to
+be enforces in later versions of Reckoner.
+
 ## [0.12.0]
 
 ### Deprecated

--- a/reckoner/cli.py
+++ b/reckoner/cli.py
@@ -31,6 +31,9 @@ from meta import __version__
 @click.pass_context
 def cli(ctx, log_level, *args, **kwargs):
     coloredlogs.install(level=log_level)
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+        ctx.exit(1)
     pass
 
 
@@ -55,18 +58,6 @@ def plot(ctx, file=None, dry_run=False, debug=False, only=None, helm_args=None, 
 
 
 @cli.command()
-@click.pass_context
-def generate(ctx):
-    """ Takes no arguments, outputs an example plan """
-    logging.info('Generating example course as course.yml')
-    src = pkg_resources.resource_string("reckoner", "example-course.yml")
-    logging.debug(src)
-    with open("./course.yml", "w") as course_file:
-        course_file.write(src)
-
-
-@cli.command()
-@click.pass_context
-def version(ctx):
+def version():
     """ Takes no arguments, outputs version info"""
-    print(reckoner.__version__)
+    print(__version__)

--- a/reckoner/config.py
+++ b/reckoner/config.py
@@ -16,11 +16,9 @@
 
 
 import os
-import sys
 import logging
 
-from command_line_caller import call
-from exception import ReckonerCommandException
+from .command_line_caller import call
 
 
 class Config(object):

--- a/reckoner/helm/client.py
+++ b/reckoner/helm/client.py
@@ -86,7 +86,7 @@ class HelmClient(object):
 
     def rollback(self, release):
         raise NotImplementedError(
-            '''This is known bad. If you see this error then you are likely implementing the solution :)'''
+            """This is known bad. If you see this error then you are likely implementing the solution :)"""
         )
 
     def dependency_update(self, chart_path):
@@ -137,7 +137,7 @@ class HelmClient(object):
         get_ver = self.execute("version", arguments=['--short', kind], filter_non_global_flags=True)
         ver = self._find_version(get_ver.stdout)
 
-        if ver == None:
+        if ver is None:
             raise HelmClientException(
                 """Could not find version!! Could the helm response format have changed?
                 STDOUT: {}

--- a/reckoner/meta.py
+++ b/reckoner/meta.py
@@ -15,5 +15,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.12.0'
+__version__ = '1.0.0-rc1'
 __author__ = 'ReactiveOps, Inc.'

--- a/reckoner/reckoner.py
+++ b/reckoner/reckoner.py
@@ -13,14 +13,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+"""Reckoner object"""
 
 import logging
 import sys
 
-from config import Config
-from course import Course
-from helm.client import HelmClient, HelmClientException
+from .config import Config
+from .course import Course
+from .helm.client import HelmClient, HelmClientException
 
 
 class Reckoner(object):

--- a/reckoner/tests/test_cli.py
+++ b/reckoner/tests/test_cli.py
@@ -1,0 +1,97 @@
+"""Testing of CLI commands in click, contract tests"""
+
+import unittest
+import mock
+from click.testing import CliRunner
+from reckoner import cli
+
+
+class TestCli(unittest.TestCase):
+    """
+    Test all the contracts of the command line tool.
+    If something changes in here than you should consider that in your version
+    bumping scheme.
+    """
+
+    def test_version(self):
+        """Assure version subcommand exists"""
+        runner = CliRunner()
+        result = runner.invoke(cli.version)
+
+        self.assertEqual(0, result.exit_code)
+        self.assertNotEqual('', result.output)
+
+        result = runner.invoke(cli.cli, args=['--version'])
+
+        self.assertEqual(0, result.exit_code)
+        self.assertNotEqual('', result.output)
+
+    def test_group_options(self):
+        """
+        Assure we have a global command options/flags
+        This will ONLY fail if you remove an expected flag, NOT if you add a
+        new option!!
+        """
+        required = {
+            'option': [
+                '--version',
+                '--log-level',
+            ]
+        }
+        assert_required_params(required, cli.cli.params)
+
+    def test_exits_without_subcommand(self):
+        """Assure we fail when run without subcommands and show some info"""
+        runner = CliRunner()
+        result = runner.invoke(cli.cli)
+
+        self.assertEqual(1, result.exit_code)
+        self.assertNotEqual(u'', result.output)
+
+
+class TestCliPlot(unittest.TestCase):
+    @mock.patch('reckoner.cli.Reckoner', autospec=True)
+    def test_plot_exists(self, reckoner_mock):
+        """Assure we have a plot command and it calls reckoner install"""
+        reckoner_instance = reckoner_mock()
+        reckoner_instance.install.side_effect = [None]
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            with open('nonexistant.file', 'w') as fake_file:
+                fake_file.write('')
+
+            result = runner.invoke(cli.plot, args=['nonexistant.file'])
+
+        self.assertEqual(0, result.exit_code, result.output)
+        reckoner_instance.install.assert_called_once()
+
+    def test_plot_options(self):
+        required = {
+            'option': [
+                '--dry-run',
+                '--debug',
+                '--helm-args',
+                '--heading',
+                '--only',
+                '--local-development',
+            ],
+            'argument': [
+                'file',
+            ]
+        }
+
+        assert_required_params(required, cli.plot.params)
+
+
+def assert_required_params(required_options, list_of_cli_params):
+    all_params = {}
+    for param in list_of_cli_params:
+        if param.param_type_name not in all_params.keys():
+            all_params[param.param_type_name] = []
+        [all_params[param.param_type_name].append(opt) for opt in param.opts]
+
+    for opt_type, opt_type_list in required_options.items():
+        assert opt_type in all_params.keys(), "Missing option type '{}' from cli params. Check if an argument or option was removed.".format(opt_type)
+        for opt in opt_type_list:
+            assert opt in all_params[opt_type], "Option '{}' of type '{}' may be missing. Consider this contract broken and version bumping if you intend to remove the param.".format(
+                opt, opt_type)

--- a/tests/test_reckoner.py
+++ b/tests/test_reckoner.py
@@ -19,8 +19,6 @@ import unittest
 import coloredlogs
 import logging
 import os
-import git
-import subprocess
 import shutil
 import mock
 import reckoner
@@ -30,9 +28,7 @@ from reckoner.reckoner import Reckoner
 from reckoner.config import Config
 from reckoner.course import Course
 from reckoner.repository import Repository
-from reckoner.exception import MinimumVersionException, ReckonerCommandException
 from reckoner.helm.client import HelmClient
-from reckoner.helm.cmd_response import HelmCmdResponse
 
 
 class TestBase(unittest.TestCase):
@@ -353,9 +349,9 @@ class TestChart(TestBase):
                     'upgrade',
                     '--recreate-pods',
                     '--install',
-                    #'--namespace={}'.format(chart.namespace),
+                    # '--namespace={}'.format(chart.namespace),
                     chart.release_name,
-                    chart.chart_path,
+                    chart.repository.chart_path,
                 ]
             )
             if chart.name == test_environ_var_chart:
@@ -368,7 +364,7 @@ class TestChart(TestBase):
                         '--recreate-pods',
                         '--install',
                         chart.release_name,
-                        chart.chart_path,
+                        chart.repository.chart_path,
                         '--namespace={}'.format(chart.namespace),
                         '--set={}={}'.format(test_environ_var_name, test_environ_var)]
                 )
@@ -381,7 +377,7 @@ class TestChart(TestBase):
                         '--recreate-pods',
                         '--install',
                         chart.release_name,
-                        chart.chart_path,
+                        chart.repository.chart_path,
                         '--namespace={}'.format(chart.namespace),
                         '--version=0.1.0',
                         '--set-string=string=string',
@@ -429,3 +425,5 @@ class TestConfig(TestBase):
         self.assertEqual(self.c1.__dict__, self.c2.__dict__)
         self.c1.test = 'value'
         self.assertEqual(self.c1.__dict__, self.c2.__dict__)
+        self.assertIs(self.c1.test, self.c2.test)
+        self.assertIsNot(self.c1, self.c2)


### PR DESCRIPTION
## Changes
* Adjusted naming of hack_merge variable
* Added information to the deprecation warning
* Adjusted the deprecation to be fired last after the final hook (so it is easily noticed)
* More tests to assure we avoid breaking changes to the CLI params and arguments

## Features
* A new `set-values: {}` key in the chart config to use for settings `--set` for helm

## Deprecation Notice
In the future, the `values: {}` configuration of a chart will change it's
behavior (see Issue #7). The current behavior translates any `values:{}` into
`--set` for the command line helm. This makes certain object types lose their
type fidelity. This means `true` becomes `string("true")` when pushed through
`--set values=true`. To maintain the same behavior for your settings please
change `values:{}` to `set-values:{}`. This behavior deprecaton will start to
be enforces in later versions of Reckoner.