### PR TITLE
Fixed error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.0.1]
 
 ### Fixed
-* 
+* Reckoner would silently fail when a --only or --heading was defined for a
+  chart that didn't exist in your course.  
+  This behavior will still succeed if you provide at least one valid --heading
+  value. If no values are in your course then this bubbles up an error
+* Internal Fix: Reckoner Errors now are a single parent exception class
 
 ## [1.0.0]
 

--- a/reckoner/cli.py
+++ b/reckoner/cli.py
@@ -15,14 +15,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import coloredlogs
 import click
-import shutil
-from reckoner import Reckoner
-import pkg_resources
-
-from meta import __version__
+from .reckoner import Reckoner
+import exception
+from .meta import __version__
 
 
 @click.group(invoke_without_command=True)
@@ -53,8 +50,14 @@ def cli(ctx, log_level, *args, **kwargs):
                                                                        'development.')
 def plot(ctx, file=None, dry_run=False, debug=False, only=None, helm_args=None, local_development=False):
     """ Install charts with given arguments as listed in yaml file argument """
-    h = Reckoner(file=file, dryrun=dry_run, debug=debug, helm_args=helm_args, local_development=local_development)
-    h.install(only)
+    try:
+        h = Reckoner(file=file, dryrun=dry_run, debug=debug, helm_args=helm_args, local_development=local_development)
+        # Convert tuple to list
+        only = list(only)
+        h.install(only)
+    except exception.ReckonerException:
+        # This handles exceptions cleanly, no expected stack traces from reckoner code
+        ctx.exit(1)
 
 
 @cli.command()

--- a/reckoner/course.py
+++ b/reckoner/course.py
@@ -21,11 +21,11 @@ import sys
 
 import oyaml as yaml
 
-from config import Config
-from chart import Chart
-from repository import Repository
-from exception import MinimumVersionException, ReckonerCommandException
-from helm.client import HelmClient, HelmClientException
+from .config import Config
+from .chart import Chart
+from .repository import Repository
+from .exception import MinimumVersionException, ReckonerCommandException, NoChartsToInstall
+from .helm.client import HelmClient, HelmClientException
 
 from meta import __version__ as reckoner_version
 
@@ -103,7 +103,6 @@ class Course(object):
         charts in the course and calls Chart.install()
 
         """
-        _charts = []
         _failed_charts = []
         self._charts_to_install = []
 
@@ -115,6 +114,19 @@ class Course(object):
         for chart in self.charts:
             if chart.release_name in charts_to_install:
                 self._charts_to_install.append(chart)
+                charts_to_install.remove(chart.release_name)
+            else:
+                logging.debug(
+                    'Skipping {} in course.yml, not found '
+                    'in your requested charts list'.format(chart.release_name)
+                )
+
+        if len(self._charts_to_install) == 0:
+            raise NoChartsToInstall(
+                'No charts found from requested list ({}). They do not exist '
+                'in the course.yml. Verify you are using the release-name '
+                'and not the chart name.'.format(', '.join(charts_to_install))
+            )
 
         for chart in self._charts_to_install:
             logging.info("Installing {}".format(chart.release_name))
@@ -125,15 +137,24 @@ class Course(object):
                     logging.error(e.stderr)
                 if type(e) == Exception:
                     logging.error(e)
-                logging.error('Helm upgrade failed. Rolling back {}'.format(chart.release_name))
+                logging.error('Helm upgrade failed on {}'.format(chart.release_name))
                 logging.debug(traceback.format_exc())
-                chart.rollback
+                # chart.rollback #TODO Fix this - it doesn't actually fire or work
                 _failed_charts.append(chart)
 
         if _failed_charts:
-            logging.error("ERROR: Some charts failed to install and were rolled back")
+            logging.error("ERROR: Some charts failed to install.")
             for chart in _failed_charts:
                 logging.error(" - {}".format(chart.release_name))
+
+        if charts_to_install:
+            for missing_chart in charts_to_install:
+                logging.warning(
+                    'Could not find {} in course.yml'.format(missing_chart)
+                )
+            logging.warning('Some of the requested charts were not found in '
+                            'your course.yml')
+
         return True
 
     def _compare_required_versions(self):

--- a/reckoner/exception.py
+++ b/reckoner/exception.py
@@ -19,11 +19,15 @@ class ReckonerException(Exception):
     pass
 
 
+class NoChartsToInstall(ReckonerException):
+    pass
+
+
 class MinimumVersionException(ReckonerException):
     pass
 
 
-class ReckonerCommandException(Exception):
+class ReckonerCommandException(ReckonerException):
 
     def __init__(self, msg, stdout=None, stderr=None, exitcode=None):
         self.message = msg

--- a/reckoner/reckoner.py
+++ b/reckoner/reckoner.py
@@ -21,6 +21,7 @@ import sys
 from .config import Config
 from .course import Course
 from .helm.client import HelmClient, HelmClientException
+from .exception import NoChartsToInstall, ReckonerCommandException
 
 
 class Reckoner(object):
@@ -85,7 +86,23 @@ class Reckoner(object):
 
         """
         selected_charts = charts or [chart._release_name for chart in self.course.charts]
-        return self.course.plot(selected_charts)
+        try:
+            self.course.plot(selected_charts)
+        except NoChartsToInstall as error:
+            logging.error(error)
+            raise ReckonerCommandException('Failed to find any valid charts to install.')
+
+        # HACK - Nick Huanca
+        # This is to satisfy a test requirement but the bool contract is a
+        # farse. The called plot command only ever raised an error or returned
+        # True. Having this always return True doesn't make sense and needs to
+        # be refactored to either have logic for WHY you want True or False.
+        # The upstream use of this code doesn't do anything with the return
+        # values of this function. (reckoner.cli.plot)
+        # The Tests:
+        #   - TestReckonerMethods.test_install_succeeds
+        #   - TestReckoner.test_install
+        return True
 
     # TODO this doesn't actually work to update context - missing _context attribute.
     #      also missing subprocess function

--- a/reckoner/tests/test_reckoner.py
+++ b/reckoner/tests/test_reckoner.py
@@ -1,0 +1,34 @@
+import unittest
+import mock
+
+from reckoner.helm.client import HelmClientException
+from reckoner.reckoner import Reckoner
+from reckoner.exception import ReckonerCommandException, NoChartsToInstall
+
+
+@mock.patch('reckoner.reckoner.Course')
+@mock.patch('reckoner.reckoner.HelmClient')
+@mock.patch('reckoner.reckoner.Config', autospec=True)
+class TestReckoner(unittest.TestCase):
+    """Test reckoner class"""
+
+    @mock.patch('reckoner.reckoner.sys')
+    def test_reckoner_raises_errors_on_bad_client_response(self, mock_sys, mock_config, mock_helm_client, *args):
+        """Make sure helm client exceptions are raised"""
+        mock_sys.exit.return_value = True
+
+        # Check helm client exception checking command
+        helm_instance = mock_helm_client()
+        helm_instance.check_helm_command.side_effect = [HelmClientException('broken')]
+        Reckoner()
+        mock_sys.exit.assert_called_once()
+        helm_instance.check_helm_command.assert_called_once()
+
+    def test_reckoner_raises_no_charts_correctly(self, mock_config, mock_helm_client, mock_course):
+        """Assure we fail when NoChartsToInstall is bubbled up"""
+        course_instance = mock_course()
+        course_instance.plot.side_effect = [NoChartsToInstall('none')]
+
+        reckoner_instance = Reckoner()
+        with self.assertRaises(ReckonerCommandException):
+            reckoner_instance.install()

--- a/tests/test_reckoner.py
+++ b/tests/test_reckoner.py
@@ -29,6 +29,7 @@ from reckoner.config import Config
 from reckoner.course import Course
 from reckoner.repository import Repository
 from reckoner.helm.client import HelmClient
+from reckoner import exception
 
 
 class TestBase(unittest.TestCase):
@@ -93,6 +94,51 @@ class TestReckonerMethods(TestBase):
         install_response = reckoner_instance.install()
         self.assertIsInstance(install_response, bool)
         self.assertTrue(install_response)
+
+
+class TestCourseMocks(unittest.TestCase):
+    @mock.patch('reckoner.course.yaml', autospec=True)
+    @mock.patch('reckoner.course.HelmClient', autospec=True)
+    def test_raises_errors_when_missing_heading(self, mock_helm, mock_yaml):
+        course_yml = {
+            'namespace': 'fake',
+            'charts': {
+                'fake-chart': {
+                    'chart': 'none',
+                    'version': 'none',
+                    'repository': 'none',
+                }
+            }
+        }
+
+        mock_yaml.load.side_effect = [course_yml]
+        helm_instance = mock_helm()
+        helm_instance.client_version = '0.0.0'
+
+        instance = reckoner.course.Course(None)
+        with self.assertRaises(exception.NoChartsToInstall):
+            instance.plot(['a-chart-that-is-not-defined'])
+
+    @mock.patch('reckoner.course.yaml', autospec=True)
+    @mock.patch('reckoner.course.HelmClient', autospec=True)
+    def test_passes_if_any_charts_exist(self, mock_helm, mock_yaml):
+        course_yml = {
+            'namespace': 'fake',
+            'charts': {
+                'fake-chart': {
+                    'chart': 'none',
+                    'version': 'none',
+                    'repository': 'none',
+                }
+            }
+        }
+
+        mock_yaml.load.side_effect = [course_yml]
+        helm_instance = mock_helm()
+        helm_instance.client_version = '0.0.0'
+
+        instance = reckoner.course.Course(None)
+        self.assertTrue(instance.plot(['a-chart-that-is-not-defined', 'fake-chart']))
 
 
 test_course = "./tests/test_course.yml"


### PR DESCRIPTION
Reckoner now raises an error to the user and is handled gracefully by click.

* Added error handling to click plot command to expect reckoner exceptions
* Fixed inheritance of reckoner exceptions
* Added tests around this new behavior
* Added testing to assure if at least a single chart in --only is correct, the run still succeeds but warns you at the end of missing charts
* Removed mention of "rollback" - because it hasn't worked since the reckoner rename