### PR TITLE
Fixing issue 59

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   This behavior will still succeed if you provide at least one valid --heading
   value. If no values are in your course then this bubbles up an error
 * Internal Fix: Reckoner Errors now are a single parent exception class
+* Fixed hook output to user instead of hidden only in debug (#59)
 
 ## [1.0.0]
 

--- a/reckoner/chart.py
+++ b/reckoner/chart.py
@@ -138,10 +138,10 @@ class Chart(object):
 
         for command in commands:
             if self.config.local_development or self.config.dryrun:
-                logging.info("Hook not run due to --dry-run: {}".format(command))
+                logging.warning("Hook not run due to --dry-run: {}".format(command))
                 continue
             else:
-                logging.info("Running {} hook.".format(hook_type))
+                logging.info("Running {} hook...".format(hook_type))
 
             try:
                 result = call(command, shell=True, executable="/bin/bash")
@@ -153,6 +153,8 @@ class Chart(object):
                 )
 
             logging.info("Ran Hook: '{}'".format(result.command_string))
+            _output_level = logging.INFO  # The level to log the command output
+
             # HACK We're not relying opon the truthiness of this object due to
             # the inability to mock is well in code
             # Python 3 may have better mocking functionality or we should
@@ -163,12 +165,16 @@ class Chart(object):
             else:
                 logging.error("{} hook failed to run".format(hook_type))
                 logging.error("Returned exit code: {}".format(result.exitcode))
+                # Override message level response to bubble up error visibility
+                _output_level = logging.ERROR
             # only print stdout if there is content
             if result.stdout:
-                logging.info("Returned stdout: {}".format(result.stdout))
+                logging.log(_output_level,
+                            "Returned stdout: {}".format(result.stdout))
             # only print stderr if there is content
             if result.stderr:
-                logging.info("Returned stderr: {}".format(result.stderr))
+                logging.log(_output_level,
+                            "Returned stderr: {}".format(result.stderr))
 
     def rollback(self):
         """ Rollsback most recent release of the course chart """

--- a/reckoner/chart.py
+++ b/reckoner/chart.py
@@ -130,30 +130,48 @@ class Chart(object):
 
     def run_hook(self, hook_type):
         """ Hook Type. Runs the commands defined by the hook """
-        commands = self.__get_hook(hook_type)
+        commands = self._get_hook(hook_type)
         if commands is None:
             return commands
         if type(commands) == str:
             commands = [commands]
 
-        for com in commands:
+        for command in commands:
             if self.config.local_development or self.config.dryrun:
-                logging.info("Hook not run due to --dry-run: {}".format(com))
+                logging.info("Hook not run due to --dry-run: {}".format(command))
                 continue
             else:
                 logging.info("Running {} hook.".format(hook_type))
 
             try:
-                r = call(com, shell=True, executable="/bin/bash")
-                logging.debug(r)
-            except ReckonerCommandException, e:
+                result = call(command, shell=True, executable="/bin/bash")
+            except Exception as error:
+                logging.error(error)
+                raise ReckonerCommandException(
+                    "Uncaught exception while running hook "
+                    "'{}'".format(command)
+                )
+
+            logging.info("Ran Hook: '{}'".format(result.command_string))
+            # HACK We're not relying opon the truthiness of this object due to
+            # the inability to mock is well in code
+            # Python 3 may have better mocking functionality or we should
+            # refactor to leverage more method on the function for .succeeded()
+            # or something similar.
+            if result.exitcode == 0:
+                logging.info("{} hook ran successfully".format(hook_type))
+            else:
                 logging.error("{} hook failed to run".format(hook_type))
-                logging.debug('Hook stderr {}'.format(e.stderr))
-                raise e
+                logging.error("Returned exit code: {}".format(result.exitcode))
+            # only print stdout if there is content
+            if result.stdout:
+                logging.info("Returned stdout: {}".format(result.stdout))
+            # only print stderr if there is content
+            if result.stderr:
+                logging.info("Returned stderr: {}".format(result.stderr))
 
     def rollback(self):
         """ Rollsback most recent release of the course chart """
-
         release = [release for release in self.helm.releases.deployed if release.name == self._release_name][0]
         if release:
             release.rollback()
@@ -204,7 +222,7 @@ class Chart(object):
         self.build_helm_arguments_for_chart()
 
         # Check and Error if we're missing required env vars
-        self.__check_env_vars()
+        self._check_env_vars()
 
         # Perform the upgrade with the arguments
         try:
@@ -268,30 +286,6 @@ class Chart(object):
 
         # Build the list of --set-string arguments
         self.build_set_string_arguments()
-
-    def _merge_set_and_values(self):
-        """
-        This is a temporary method that will be gone once the values: vs set:
-        debacle has been resolved. (See https://github.com/reactiveops/reckoner/issues/7)
-
-        NOTE ONLY RUN THIS ONCE BECAUSE IT'S NOT IDEMPOTENT
-        """
-        if self._hack_set_values_already_merged:
-            raise StandardError('This method cannot be called twice. '
-                                'If you are seeing this please open an '
-                                'issue in github.')
-
-        def merge_dicts(values, sets):
-            """This does a dict merge and prefers "sets" values"""
-            new_dict = values.copy()
-            new_dict.update(sets)
-            return new_dict
-
-        logging.debug('Merging values: into sets: - sets: take precedence.')
-        logging.debug('Original value of sets: {}'.format(self.set_values))
-        self.set_values = merge_dicts(self.values, self.set_values)
-        logging.debug('New value of sets: {}'.format(self.set_values))
-        self._hack_set_values_already_merged = True
 
     def build_temp_values_files(self):
         """
@@ -372,14 +366,38 @@ class Chart(object):
     def __getattr__(self, key):
         return self._chart.get(key)
 
+    def _merge_set_and_values(self):
+        """
+        This is a temporary method that will be gone once the values: vs set:
+        debacle has been resolved. (See https://github.com/reactiveops/reckoner/issues/7)
+
+        NOTE ONLY RUN THIS ONCE BECAUSE IT'S NOT IDEMPOTENT
+        """
+        if self._hack_set_values_already_merged:
+            raise StandardError('This method cannot be called twice. '
+                                'If you are seeing this please open an '
+                                'issue in github.')
+
+        def merge_dicts(values, sets):
+            """This does a dict merge and prefers "sets" values"""
+            new_dict = values.copy()
+            new_dict.update(sets)
+            return new_dict
+
+        logging.debug('Merging values: into sets: - sets: take precedence.')
+        logging.debug('Original value of sets: {}'.format(self.set_values))
+        self.set_values = merge_dicts(self.values, self.set_values)
+        logging.debug('New value of sets: {}'.format(self.set_values))
+        self._hack_set_values_already_merged = True
+
     def __str__(self):
         return str(dict(self._chart))
 
-    def __get_hook(self, hook_type):
+    def _get_hook(self, hook_type):
         if self.hooks is not None:
             return self.hooks.get(hook_type)
 
-    def __check_env_vars(self):
+    def _check_env_vars(self):
         """
         accepts list of args
         if any of those appear to be env vars

--- a/reckoner/command_line_caller/__init__.py
+++ b/reckoner/command_line_caller/__init__.py
@@ -34,16 +34,17 @@ class Response(object):
     - exitcode
 
     Returns:
-    - Instance of Response() is truthy where Reponse.exitcode == 0
-    - Instance Response() is falsey where Reponse.exitcode != 0
+    - Instance of Response() is truthy where Response.exitcode == 0
+    - Instance Response() is falsey where Response.exitcode != 0
     """
 
-    def __init__(self, stdout, stderr, exitcode):
+    def __init__(self, stdout, stderr, exitcode, command_string):
 
         self._dict = {}
         self._dict['stdout'] = stdout
         self._dict['stderr'] = stderr
         self._dict['exitcode'] = exitcode
+        self._dict['command_string'] = command_string
 
     def __getattr__(self, name):
         return self._dict.get(name)
@@ -51,7 +52,8 @@ class Response(object):
     def __str__(self):
         return str(self._dict)
 
-    def __bool__(self):
+    # TODO Python3 candidate for migration to __bool__()
+    def __nonzero__(self):
         return not self._dict['exitcode']
 
     def __eq__(self, other):
@@ -79,4 +81,4 @@ def call(args, shell=False, executable=None):
     stdout, stderr = p.communicate()
     exitcode = p.returncode
 
-    return Response(stdout, stderr, exitcode)
+    return Response(stdout, stderr, exitcode, args_string)

--- a/reckoner/command_line_caller/tests/test_command_line_caller.py
+++ b/reckoner/command_line_caller/tests/test_command_line_caller.py
@@ -1,0 +1,22 @@
+import unittest
+from reckoner.command_line_caller import Response
+
+
+class TestResponse(unittest.TestCase):
+    def test_properties(self):
+        required_attrs = {
+            'stdout': 'stdout value',
+            'stderr': 'stderr value',
+            'exitcode': 0,
+            'command_string': 'command -that -ran',
+        }
+        response = Response(**required_attrs)
+        for attr, value in required_attrs.items():
+            self.assertEqual(getattr(response, attr), value)
+
+    def test_bool(self):
+        response = Response('', '', 127, '')
+        self.assertFalse(response, "Any response where exitcode is not 0 should return false")
+
+        response = Response('', '', 0, '')
+        self.assertTrue(response, "All responses with exitcode 0 should return True")

--- a/reckoner/helm/tests/test_provider.py
+++ b/reckoner/helm/tests/test_provider.py
@@ -19,7 +19,7 @@ class TestAllProviders(unittest.TestCase):
         for provider in self._list_of_providers:
             helm_cmd = HelmCommand('mocking-helm', ['--debug'])
             call_mock.side_effect = [
-                Response('stdout', 'stderr', 0)
+                Response('stdout', 'stderr', 0, None)
             ]
             inst = provider.execute(helm_cmd)
             assert call_mock.assert_called_once

--- a/reckoner/reckoner.py
+++ b/reckoner/reckoner.py
@@ -48,8 +48,8 @@ class Reckoner(object):
         self.config = Config()
         self.config.dryrun = dryrun
         self.config.debug = debug
-        self.config.helm_args = helm_args
         self.config.local_development = local_development
+        self.config.helm_args = helm_args
 
         if self.config.debug:
             logging.warn("The --debug flag will be deprecated.  Please use --helm-args or --dry-run instead.")

--- a/reckoner/tests/test_chart.py
+++ b/reckoner/tests/test_chart.py
@@ -1,0 +1,61 @@
+"""Test the chart functions directly"""
+import unittest
+import mock
+from reckoner.chart import Chart
+from reckoner.command_line_caller import Response
+from reckoner.exception import ReckonerCommandException
+
+
+@mock.patch('reckoner.chart.Repository')
+@mock.patch('reckoner.chart.Config')
+# I have to strictly design the mock for Reckoner due to the nature of the
+# key/val class setup. If the class actually had attributes then this
+# would be more easily mockable
+@mock.patch('reckoner.chart.call')
+class TestChartHooks(unittest.TestCase):
+    def setUp(self):
+        self._chart = Chart(
+            {'name': {
+                'hooks': {
+                    'pre_install': [
+                        'omg',
+                    ],
+                    'post_install': [
+                        'fetchez --la-vache',
+                        'mooooooooo!',
+                    ]
+                }
+            }
+            },
+            None,
+        )
+
+    def test_caught_exceptions(self, mock_cmd_call, *args):
+        """Assert that we raise the correct error if call() blows up"""
+        mock_cmd_call.side_effect = [Exception('holy smokes, an error!')]
+        with self.assertRaises(ReckonerCommandException):
+            self._chart.run_hook('pre_install')
+
+    @mock.patch('reckoner.chart.logging')
+    def test_logging_info_and_errors(self, mock_logging, mock_cmd_call, *args):
+        """Verify we log the right info when call() fails and succeeds"""
+        bad_response = mock.Mock(Response,
+                                 exitcode=1,
+                                 stderr='some error',
+                                 stdout='some info',
+                                 command_string='my --command')
+        good_response = mock.Mock(Response,
+                                  exitcode=0,
+                                  stderr='',
+                                  stdout='some info',
+                                  command_string='my --command')
+        mock_cmd_call.side_effect = [good_response]
+        self._chart.run_hook('pre_install')
+        self.assertEqual(mock_logging.error.call_count, 0)
+        self.assertTrue(mock_logging.info.call_count > 0)
+
+        mock_cmd_call.side_effect = [bad_response, good_response]
+        mock_logging.reset_mock()
+        self._chart.run_hook('post_install')
+        self.assertTrue(mock_logging.error.call_count > 0)
+        self.assertTrue(mock_logging.info.call_count > 0)

--- a/reckoner/tests/test_chart.py
+++ b/reckoner/tests/test_chart.py
@@ -66,13 +66,13 @@ class TestChartHooks(unittest.TestCase):
         mock_logging.info.assert_called()
         mock_logging.log.assert_called()
 
-    def test_skipping_due_to_local_development(self, mock_cmd_call, mock_config, *args):
-        """Verify that we do NOT run the actual calls when in local_development"""
+    def test_skipping_due_to_local_development(self, mock_cmd_call, *args):
+        """Verify skipping call() when in local_development"""
         self._chart.config.local_development = True
         self._chart.run_hook('pre_install')
         mock_cmd_call.assert_not_called()
 
-    def test_skipping_due_to_dryrun(self, mock_cmd_call, mock_config, *args):
+    def test_skipping_due_to_dryrun(self, mock_cmd_call, *args):
         """Verify that we do NOT run the actual calls when dryrun is enabled"""
         self._chart.config.dryrun = True
         self._chart.run_hook('pre_install')

--- a/reckoner/tests/test_chart.py
+++ b/reckoner/tests/test_chart.py
@@ -65,3 +65,15 @@ class TestChartHooks(unittest.TestCase):
         mock_logging.error.assert_called()
         mock_logging.info.assert_called()
         mock_logging.log.assert_called()
+
+    def test_skipping_due_to_local_development(self, mock_cmd_call, mock_config, *args):
+        """Verify that we do NOT run the actual calls when in local_development"""
+        self._chart.config.local_development = True
+        self._chart.run_hook('pre_install')
+        mock_cmd_call.assert_not_called()
+
+    def test_skipping_due_to_dryrun(self, mock_cmd_call, mock_config, *args):
+        """Verify that we do NOT run the actual calls when dryrun is enabled"""
+        self._chart.config.dryrun = True
+        self._chart.run_hook('pre_install')
+        mock_cmd_call.assert_not_called()


### PR DESCRIPTION
#59 is addressed in this PR

Behavior today was only showing output of hooks, regardless of failure, in the debug output. We fixed up the handling of errors to match what the call() function returns. This now checks for exit success and will log stderr and stdout if there is anything to bubble up.