### PR TITLE
Run hooks from course.yml directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   value. If no values are in your course then this bubbles up an error
 * Internal Fix: Reckoner Errors now are a single parent exception class
 * Fixed hook output to user instead of hidden only in debug (#59)
+* Fixed hooks to run from the same path as course.yml. This makes PWD relative
+  to course.yml for easier groking of paths for hook pre/post install.
 
 ## [1.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.0.1]
 
 ### Fixed
-* 
+* Reckoner would silently fail when a --only or --heading was defined for a
+  chart that didn't exist in your course.  
+  This behavior will still succeed if you provide at least one valid --heading
+  value. If no values are in your course then this bubbles up an error
+* Internal Fix: Reckoner Errors now are a single parent exception class
 
 ## [1.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   This behavior will still succeed if you provide at least one valid --heading
   value. If no values are in your course then this bubbles up an error
 * Internal Fix: Reckoner Errors now are a single parent exception class
+* Fixed hook output to user instead of hidden only in debug (#59)
 
 ## [1.0.0]
 

--- a/reckoner/chart.py
+++ b/reckoner/chart.py
@@ -138,10 +138,10 @@ class Chart(object):
 
         for command in commands:
             if self.config.local_development or self.config.dryrun:
-                logging.info("Hook not run due to --dry-run: {}".format(command))
+                logging.warning("Hook not run due to --dry-run: {}".format(command))
                 continue
             else:
-                logging.info("Running {} hook.".format(hook_type))
+                logging.info("Running {} hook...".format(hook_type))
 
             try:
                 result = call(command, shell=True, executable="/bin/bash")
@@ -153,6 +153,8 @@ class Chart(object):
                 )
 
             logging.info("Ran Hook: '{}'".format(result.command_string))
+            _output_level = logging.INFO  # The level to log the command output
+
             # HACK We're not relying opon the truthiness of this object due to
             # the inability to mock is well in code
             # Python 3 may have better mocking functionality or we should
@@ -163,12 +165,16 @@ class Chart(object):
             else:
                 logging.error("{} hook failed to run".format(hook_type))
                 logging.error("Returned exit code: {}".format(result.exitcode))
+                # Override message level response to bubble up error visibility
+                _output_level = logging.ERROR
             # only print stdout if there is content
             if result.stdout:
-                logging.info("Returned stdout: {}".format(result.stdout))
+                logging.log(_output_level,
+                            "Returned stdout: {}".format(result.stdout))
             # only print stderr if there is content
             if result.stderr:
-                logging.info("Returned stderr: {}".format(result.stderr))
+                logging.log(_output_level,
+                            "Returned stderr: {}".format(result.stderr))
 
     def rollback(self):
         """ Rollsback most recent release of the course chart """

--- a/reckoner/chart.py
+++ b/reckoner/chart.py
@@ -144,7 +144,12 @@ class Chart(object):
                 logging.info("Running {} hook...".format(hook_type))
 
             try:
-                result = call(command, shell=True, executable="/bin/bash")
+                result = call(
+                    command,
+                    shell=True,
+                    executable="/bin/bash",
+                    path=self.config.course_base_directory
+                )
             except Exception as error:
                 logging.error(error)
                 raise ReckonerCommandException(

--- a/reckoner/chart.py
+++ b/reckoner/chart.py
@@ -130,30 +130,48 @@ class Chart(object):
 
     def run_hook(self, hook_type):
         """ Hook Type. Runs the commands defined by the hook """
-        commands = self.__get_hook(hook_type)
+        commands = self._get_hook(hook_type)
         if commands is None:
             return commands
         if type(commands) == str:
             commands = [commands]
 
-        for com in commands:
+        for command in commands:
             if self.config.local_development or self.config.dryrun:
-                logging.info("Hook not run due to --dry-run: {}".format(com))
+                logging.info("Hook not run due to --dry-run: {}".format(command))
                 continue
             else:
                 logging.info("Running {} hook.".format(hook_type))
 
             try:
-                r = call(com, shell=True, executable="/bin/bash")
-                logging.debug(r)
-            except ReckonerCommandException, e:
+                result = call(command, shell=True, executable="/bin/bash")
+            except Exception as error:
+                logging.error(error)
+                raise ReckonerCommandException(
+                    "Uncaught exception while running hook "
+                    "'{}'".format(command)
+                )
+
+            logging.info("Ran Hook: '{}'".format(result.command_string))
+            # HACK We're not relying opon the truthiness of this object due to
+            # the inability to mock is well in code
+            # Python 3 may have better mocking functionality or we should
+            # refactor to leverage more method on the function for .succeeded()
+            # or something similar.
+            if result.exitcode == 0:
+                logging.info("{} hook ran successfully".format(hook_type))
+            else:
                 logging.error("{} hook failed to run".format(hook_type))
-                logging.debug('Hook stderr {}'.format(e.stderr))
-                raise e
+                logging.error("Returned exit code: {}".format(result.exitcode))
+            # only print stdout if there is content
+            if result.stdout:
+                logging.info("Returned stdout: {}".format(result.stdout))
+            # only print stderr if there is content
+            if result.stderr:
+                logging.info("Returned stderr: {}".format(result.stderr))
 
     def rollback(self):
         """ Rollsback most recent release of the course chart """
-
         release = [release for release in self.helm.releases.deployed if release.name == self._release_name][0]
         if release:
             release.rollback()
@@ -204,7 +222,7 @@ class Chart(object):
         self.build_helm_arguments_for_chart()
 
         # Check and Error if we're missing required env vars
-        self.__check_env_vars()
+        self._check_env_vars()
 
         # Perform the upgrade with the arguments
         try:
@@ -268,30 +286,6 @@ class Chart(object):
 
         # Build the list of --set-string arguments
         self.build_set_string_arguments()
-
-    def _merge_set_and_values(self):
-        """
-        This is a temporary method that will be gone once the values: vs set:
-        debacle has been resolved. (See https://github.com/reactiveops/reckoner/issues/7)
-
-        NOTE ONLY RUN THIS ONCE BECAUSE IT'S NOT IDEMPOTENT
-        """
-        if self._hack_set_values_already_merged:
-            raise StandardError('This method cannot be called twice. '
-                                'If you are seeing this please open an '
-                                'issue in github.')
-
-        def merge_dicts(values, sets):
-            """This does a dict merge and prefers "sets" values"""
-            new_dict = values.copy()
-            new_dict.update(sets)
-            return new_dict
-
-        logging.debug('Merging values: into sets: - sets: take precedence.')
-        logging.debug('Original value of sets: {}'.format(self.set_values))
-        self.set_values = merge_dicts(self.values, self.set_values)
-        logging.debug('New value of sets: {}'.format(self.set_values))
-        self._hack_set_values_already_merged = True
 
     def build_temp_values_files(self):
         """
@@ -372,14 +366,38 @@ class Chart(object):
     def __getattr__(self, key):
         return self._chart.get(key)
 
+    def _merge_set_and_values(self):
+        """
+        This is a temporary method that will be gone once the values: vs set:
+        debacle has been resolved. (See https://github.com/reactiveops/reckoner/issues/7)
+
+        NOTE ONLY RUN THIS ONCE BECAUSE IT'S NOT IDEMPOTENT
+        """
+        if self._hack_set_values_already_merged:
+            raise StandardError('This method cannot be called twice. '
+                                'If you are seeing this please open an '
+                                'issue in github.')
+
+        def merge_dicts(values, sets):
+            """This does a dict merge and prefers "sets" values"""
+            new_dict = values.copy()
+            new_dict.update(sets)
+            return new_dict
+
+        logging.debug('Merging values: into sets: - sets: take precedence.')
+        logging.debug('Original value of sets: {}'.format(self.set_values))
+        self.set_values = merge_dicts(self.values, self.set_values)
+        logging.debug('New value of sets: {}'.format(self.set_values))
+        self._hack_set_values_already_merged = True
+
     def __str__(self):
         return str(dict(self._chart))
 
-    def __get_hook(self, hook_type):
+    def _get_hook(self, hook_type):
         if self.hooks is not None:
             return self.hooks.get(hook_type)
 
-    def __check_env_vars(self):
+    def _check_env_vars(self):
         """
         accepts list of args
         if any of those appear to be env vars

--- a/reckoner/cli.py
+++ b/reckoner/cli.py
@@ -15,14 +15,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import coloredlogs
 import click
-import shutil
-from reckoner import Reckoner
-import pkg_resources
-
-from meta import __version__
+from .reckoner import Reckoner
+import exception
+from .meta import __version__
 
 
 @click.group(invoke_without_command=True)
@@ -53,8 +50,14 @@ def cli(ctx, log_level, *args, **kwargs):
                                                                        'development.')
 def plot(ctx, file=None, dry_run=False, debug=False, only=None, helm_args=None, local_development=False):
     """ Install charts with given arguments as listed in yaml file argument """
-    h = Reckoner(file=file, dryrun=dry_run, debug=debug, helm_args=helm_args, local_development=local_development)
-    h.install(only)
+    try:
+        h = Reckoner(file=file, dryrun=dry_run, debug=debug, helm_args=helm_args, local_development=local_development)
+        # Convert tuple to list
+        only = list(only)
+        h.install(only)
+    except exception.ReckonerException:
+        # This handles exceptions cleanly, no expected stack traces from reckoner code
+        ctx.exit(1)
 
 
 @cli.command()

--- a/reckoner/cli.py
+++ b/reckoner/cli.py
@@ -36,7 +36,7 @@ def cli(ctx, log_level, *args, **kwargs):
 
 @cli.command()
 @click.pass_context
-@click.argument('file', type=click.File('rb'))
+@click.argument('course_file', type=click.File('rb'))
 @click.option("--dry-run", is_flag=True, help='Pass --dry-run to helm so no action is taken. Implies --debug and '
                                               'skips hooks.')
 @click.option("--debug", is_flag=True, help='DEPRECATED - use --dry-run instead, or pass to --helm-args')
@@ -48,10 +48,10 @@ def cli(ctx, log_level, *args, **kwargs):
                                                                        'where Tiller is not required and no helm '
                                                                        'commands are run. Useful for rapid or offline '
                                                                        'development.')
-def plot(ctx, file=None, dry_run=False, debug=False, only=None, helm_args=None, local_development=False):
+def plot(ctx, course_file=None, dry_run=False, debug=False, only=None, helm_args=None, local_development=False):
     """ Install charts with given arguments as listed in yaml file argument """
     try:
-        h = Reckoner(file=file, dryrun=dry_run, debug=debug, helm_args=helm_args, local_development=local_development)
+        h = Reckoner(course_file=course_file, dryrun=dry_run, debug=debug, helm_args=helm_args, local_development=local_development)
         # Convert tuple to list
         only = list(only)
         h.install(only)

--- a/reckoner/command_line_caller/__init__.py
+++ b/reckoner/command_line_caller/__init__.py
@@ -60,7 +60,7 @@ class Response(object):
         return self._dict == other._dict
 
 
-def call(args, shell=False, executable=None):
+def call(args, shell=False, executable=None, path=None):
     """
     Description:
     - Wrapper for subprocess.Popen. Joins `args` and passes
@@ -77,7 +77,7 @@ def call(args, shell=False, executable=None):
     else:
         args_string = ' '.join(args)
     logging.debug(args_string)
-    p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=shell, executable=executable)
+    p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=shell, executable=executable, cwd=path)
     stdout, stderr = p.communicate()
     exitcode = p.returncode
 

--- a/reckoner/command_line_caller/__init__.py
+++ b/reckoner/command_line_caller/__init__.py
@@ -34,16 +34,17 @@ class Response(object):
     - exitcode
 
     Returns:
-    - Instance of Response() is truthy where Reponse.exitcode == 0
-    - Instance Response() is falsey where Reponse.exitcode != 0
+    - Instance of Response() is truthy where Response.exitcode == 0
+    - Instance Response() is falsey where Response.exitcode != 0
     """
 
-    def __init__(self, stdout, stderr, exitcode):
+    def __init__(self, stdout, stderr, exitcode, command_string):
 
         self._dict = {}
         self._dict['stdout'] = stdout
         self._dict['stderr'] = stderr
         self._dict['exitcode'] = exitcode
+        self._dict['command_string'] = command_string
 
     def __getattr__(self, name):
         return self._dict.get(name)
@@ -51,7 +52,8 @@ class Response(object):
     def __str__(self):
         return str(self._dict)
 
-    def __bool__(self):
+    # TODO Python3 candidate for migration to __bool__()
+    def __nonzero__(self):
         return not self._dict['exitcode']
 
     def __eq__(self, other):
@@ -79,4 +81,4 @@ def call(args, shell=False, executable=None):
     stdout, stderr = p.communicate()
     exitcode = p.returncode
 
-    return Response(stdout, stderr, exitcode)
+    return Response(stdout, stderr, exitcode, args_string)

--- a/reckoner/command_line_caller/tests/test_command_line_caller.py
+++ b/reckoner/command_line_caller/tests/test_command_line_caller.py
@@ -1,0 +1,22 @@
+import unittest
+from reckoner.command_line_caller import Response
+
+
+class TestResponse(unittest.TestCase):
+    def test_properties(self):
+        required_attrs = {
+            'stdout': 'stdout value',
+            'stderr': 'stderr value',
+            'exitcode': 0,
+            'command_string': 'command -that -ran',
+        }
+        response = Response(**required_attrs)
+        for attr, value in required_attrs.items():
+            self.assertEqual(getattr(response, attr), value)
+
+    def test_bool(self):
+        response = Response('', '', 127, '')
+        self.assertFalse(response, "Any response where exitcode is not 0 should return false")
+
+        response = Response('', '', 0, '')
+        self.assertTrue(response, "All responses with exitcode 0 should return True")

--- a/reckoner/config.py
+++ b/reckoner/config.py
@@ -17,6 +17,7 @@
 
 import os
 import logging
+from os.path import dirname
 
 from .command_line_caller import call
 
@@ -66,6 +67,13 @@ class Config(object):
             self._config['archive'] = archive
 
         return self._config['archive']
+
+    @property
+    def course_base_directory(self):
+        if self.course_path:
+            return dirname(self.course_path)
+        else:
+            return None
 
     def __setattr__(self, name, value):
         object.__setattr__(self, name, value)

--- a/reckoner/course.py
+++ b/reckoner/course.py
@@ -21,11 +21,11 @@ import sys
 
 import oyaml as yaml
 
-from config import Config
-from chart import Chart
-from repository import Repository
-from exception import MinimumVersionException, ReckonerCommandException
-from helm.client import HelmClient, HelmClientException
+from .config import Config
+from .chart import Chart
+from .repository import Repository
+from .exception import MinimumVersionException, ReckonerCommandException, NoChartsToInstall
+from .helm.client import HelmClient, HelmClientException
 
 from meta import __version__ as reckoner_version
 
@@ -103,7 +103,6 @@ class Course(object):
         charts in the course and calls Chart.install()
 
         """
-        _charts = []
         _failed_charts = []
         self._charts_to_install = []
 
@@ -115,6 +114,19 @@ class Course(object):
         for chart in self.charts:
             if chart.release_name in charts_to_install:
                 self._charts_to_install.append(chart)
+                charts_to_install.remove(chart.release_name)
+            else:
+                logging.debug(
+                    'Skipping {} in course.yml, not found '
+                    'in your requested charts list'.format(chart.release_name)
+                )
+
+        if len(self._charts_to_install) == 0:
+            raise NoChartsToInstall(
+                'No charts found from requested list ({}). They do not exist '
+                'in the course.yml. Verify you are using the release-name '
+                'and not the chart name.'.format(', '.join(charts_to_install))
+            )
 
         for chart in self._charts_to_install:
             logging.info("Installing {}".format(chart.release_name))
@@ -125,15 +137,24 @@ class Course(object):
                     logging.error(e.stderr)
                 if type(e) == Exception:
                     logging.error(e)
-                logging.error('Helm upgrade failed. Rolling back {}'.format(chart.release_name))
+                logging.error('Helm upgrade failed on {}'.format(chart.release_name))
                 logging.debug(traceback.format_exc())
-                chart.rollback
+                # chart.rollback #TODO Fix this - it doesn't actually fire or work
                 _failed_charts.append(chart)
 
         if _failed_charts:
-            logging.error("ERROR: Some charts failed to install and were rolled back")
+            logging.error("ERROR: Some charts failed to install.")
             for chart in _failed_charts:
                 logging.error(" - {}".format(chart.release_name))
+
+        if charts_to_install:
+            for missing_chart in charts_to_install:
+                logging.warning(
+                    'Could not find {} in course.yml'.format(missing_chart)
+                )
+            logging.warning('Some of the requested charts were not found in '
+                            'your course.yml')
+
         return True
 
     def _compare_required_versions(self):

--- a/reckoner/course.py
+++ b/reckoner/course.py
@@ -47,12 +47,12 @@ class Course(object):
 
     """
 
-    def __init__(self, file):
+    def __init__(self, course_file):
         """
         Parse course.yml contents into instances.
         """
         self.config = Config()
-        self._dict = yaml.load(file)
+        self._dict = yaml.load(course_file)
         if not self.config.helm_args:
             self.config.helm_args = self._dict.get('helm_args')
         self.helm = HelmClient(default_helm_arguments=self.config.helm_args)

--- a/reckoner/exception.py
+++ b/reckoner/exception.py
@@ -19,11 +19,15 @@ class ReckonerException(Exception):
     pass
 
 
+class NoChartsToInstall(ReckonerException):
+    pass
+
+
 class MinimumVersionException(ReckonerException):
     pass
 
 
-class ReckonerCommandException(Exception):
+class ReckonerCommandException(ReckonerException):
 
     def __init__(self, msg, stdout=None, stderr=None, exitcode=None):
         self.message = msg

--- a/reckoner/helm/tests/test_provider.py
+++ b/reckoner/helm/tests/test_provider.py
@@ -19,7 +19,7 @@ class TestAllProviders(unittest.TestCase):
         for provider in self._list_of_providers:
             helm_cmd = HelmCommand('mocking-helm', ['--debug'])
             call_mock.side_effect = [
-                Response('stdout', 'stderr', 0)
+                Response('stdout', 'stderr', 0, None)
             ]
             inst = provider.execute(helm_cmd)
             assert call_mock.assert_called_once

--- a/reckoner/reckoner.py
+++ b/reckoner/reckoner.py
@@ -21,6 +21,7 @@ import sys
 from .config import Config
 from .course import Course
 from .helm.client import HelmClient, HelmClientException
+from .exception import NoChartsToInstall, ReckonerCommandException
 
 
 class Reckoner(object):
@@ -85,7 +86,23 @@ class Reckoner(object):
 
         """
         selected_charts = charts or [chart._release_name for chart in self.course.charts]
-        return self.course.plot(selected_charts)
+        try:
+            self.course.plot(selected_charts)
+        except NoChartsToInstall as error:
+            logging.error(error)
+            raise ReckonerCommandException('Failed to find any valid charts to install.')
+
+        # HACK - Nick Huanca
+        # This is to satisfy a test requirement but the bool contract is a
+        # farse. The called plot command only ever raised an error or returned
+        # True. Having this always return True doesn't make sense and needs to
+        # be refactored to either have logic for WHY you want True or False.
+        # The upstream use of this code doesn't do anything with the return
+        # values of this function. (reckoner.cli.plot)
+        # The Tests:
+        #   - TestReckonerMethods.test_install_succeeds
+        #   - TestReckoner.test_install
+        return True
 
     # TODO this doesn't actually work to update context - missing _context attribute.
     #      also missing subprocess function

--- a/reckoner/reckoner.py
+++ b/reckoner/reckoner.py
@@ -48,8 +48,8 @@ class Reckoner(object):
         self.config = Config()
         self.config.dryrun = dryrun
         self.config.debug = debug
-        self.config.helm_args = helm_args
         self.config.local_development = local_development
+        self.config.helm_args = helm_args
 
         if self.config.debug:
             logging.warn("The --debug flag will be deprecated.  Please use --helm-args or --dry-run instead.")

--- a/reckoner/reckoner.py
+++ b/reckoner/reckoner.py
@@ -43,13 +43,14 @@ class Reckoner(object):
 
     """
 
-    def __init__(self, file=None, dryrun=False, debug=False, helm_args=None, local_development=False):
-
+    def __init__(self, course_file=None, dryrun=False, debug=False, helm_args=None, local_development=False):
         self.config = Config()
         self.config.dryrun = dryrun
         self.config.debug = debug
         self.config.local_development = local_development
         self.config.helm_args = helm_args
+        if course_file:
+            self.config.course_path = course_file.name
 
         if self.config.debug:
             logging.warn("The --debug flag will be deprecated.  Please use --helm-args or --dry-run instead.")
@@ -70,7 +71,7 @@ class Reckoner(object):
                 logging.error("Failed checking helm: See errors:\n{}".format(e))
                 sys.exit(1)
 
-        self.course = Course(file)
+        self.course = Course(course_file)
 
     def install(self, charts=[]):
         """

--- a/reckoner/tests/test_chart.py
+++ b/reckoner/tests/test_chart.py
@@ -1,0 +1,61 @@
+"""Test the chart functions directly"""
+import unittest
+import mock
+from reckoner.chart import Chart
+from reckoner.command_line_caller import Response
+from reckoner.exception import ReckonerCommandException
+
+
+@mock.patch('reckoner.chart.Repository')
+@mock.patch('reckoner.chart.Config')
+# I have to strictly design the mock for Reckoner due to the nature of the
+# key/val class setup. If the class actually had attributes then this
+# would be more easily mockable
+@mock.patch('reckoner.chart.call')
+class TestChartHooks(unittest.TestCase):
+    def setUp(self):
+        self._chart = Chart(
+            {'name': {
+                'hooks': {
+                    'pre_install': [
+                        'omg',
+                    ],
+                    'post_install': [
+                        'fetchez --la-vache',
+                        'mooooooooo!',
+                    ]
+                }
+            }
+            },
+            None,
+        )
+
+    def test_caught_exceptions(self, mock_cmd_call, *args):
+        """Assert that we raise the correct error if call() blows up"""
+        mock_cmd_call.side_effect = [Exception('holy smokes, an error!')]
+        with self.assertRaises(ReckonerCommandException):
+            self._chart.run_hook('pre_install')
+
+    @mock.patch('reckoner.chart.logging')
+    def test_logging_info_and_errors(self, mock_logging, mock_cmd_call, *args):
+        """Verify we log the right info when call() fails and succeeds"""
+        bad_response = mock.Mock(Response,
+                                 exitcode=1,
+                                 stderr='some error',
+                                 stdout='some info',
+                                 command_string='my --command')
+        good_response = mock.Mock(Response,
+                                  exitcode=0,
+                                  stderr='',
+                                  stdout='some info',
+                                  command_string='my --command')
+        mock_cmd_call.side_effect = [good_response]
+        self._chart.run_hook('pre_install')
+        self.assertEqual(mock_logging.error.call_count, 0)
+        self.assertTrue(mock_logging.info.call_count > 0)
+
+        mock_cmd_call.side_effect = [bad_response, good_response]
+        mock_logging.reset_mock()
+        self._chart.run_hook('post_install')
+        self.assertTrue(mock_logging.error.call_count > 0)
+        self.assertTrue(mock_logging.info.call_count > 0)

--- a/reckoner/tests/test_chart.py
+++ b/reckoner/tests/test_chart.py
@@ -66,13 +66,13 @@ class TestChartHooks(unittest.TestCase):
         mock_logging.info.assert_called()
         mock_logging.log.assert_called()
 
-    def test_skipping_due_to_local_development(self, mock_cmd_call, mock_config, *args):
-        """Verify that we do NOT run the actual calls when in local_development"""
+    def test_skipping_due_to_local_development(self, mock_cmd_call, *args):
+        """Verify skipping call() when in local_development"""
         self._chart.config.local_development = True
         self._chart.run_hook('pre_install')
         mock_cmd_call.assert_not_called()
 
-    def test_skipping_due_to_dryrun(self, mock_cmd_call, mock_config, *args):
+    def test_skipping_due_to_dryrun(self, mock_cmd_call, *args):
         """Verify that we do NOT run the actual calls when dryrun is enabled"""
         self._chart.config.dryrun = True
         self._chart.run_hook('pre_install')

--- a/reckoner/tests/test_chart.py
+++ b/reckoner/tests/test_chart.py
@@ -65,3 +65,15 @@ class TestChartHooks(unittest.TestCase):
         mock_logging.error.assert_called()
         mock_logging.info.assert_called()
         mock_logging.log.assert_called()
+
+    def test_skipping_due_to_local_development(self, mock_cmd_call, mock_config, *args):
+        """Verify that we do NOT run the actual calls when in local_development"""
+        self._chart.config.local_development = True
+        self._chart.run_hook('pre_install')
+        mock_cmd_call.assert_not_called()
+
+    def test_skipping_due_to_dryrun(self, mock_cmd_call, mock_config, *args):
+        """Verify that we do NOT run the actual calls when dryrun is enabled"""
+        self._chart.config.dryrun = True
+        self._chart.run_hook('pre_install')
+        mock_cmd_call.assert_not_called()

--- a/reckoner/tests/test_cli.py
+++ b/reckoner/tests/test_cli.py
@@ -57,10 +57,10 @@ class TestCliPlot(unittest.TestCase):
         reckoner_instance.install.side_effect = [None]
         runner = CliRunner()
         with runner.isolated_filesystem():
-            with open('nonexistant.file', 'w') as fake_file:
+            with open('nonexistent.file', 'wb') as fake_file:
                 fake_file.write('')
 
-            result = runner.invoke(cli.plot, args=['nonexistant.file'])
+            result = runner.invoke(cli.plot, args=['nonexistent.file'])
 
         self.assertEqual(0, result.exit_code, result.output)
         reckoner_instance.install.assert_called_once()
@@ -76,7 +76,7 @@ class TestCliPlot(unittest.TestCase):
                 '--local-development',
             ],
             'argument': [
-                'file',
+                'course_file',
             ]
         }
 

--- a/tests/test_reckoner.py
+++ b/tests/test_reckoner.py
@@ -269,7 +269,7 @@ class TestReckoner(TestBase):
         # os.chdir("../")
         self.configure_subprocess_mock(test_tiller_present_return_string, '', 0)
         with open(test_course) as f:
-            self.a = Reckoner(file=f, local_development=True)
+            self.a = Reckoner(course_file=f, local_development=True)
 
     # def tearDown(self):
     #     self.a = None
@@ -321,7 +321,7 @@ class TestChart(TestBase):
         super(type(self), self).setUp()
         self.configure_subprocess_mock(test_tiller_present_return_string, '', 0)
         with open(test_course) as f:
-            self.a = Reckoner(file=f, local_development=True)
+            self.a = Reckoner(course_file=f, local_development=True)
         self.charts = self.a.course.charts
 
     def test_releasename_is_different_than_chart_name(self):

--- a/tests/test_reckoner.py
+++ b/tests/test_reckoner.py
@@ -29,6 +29,7 @@ from reckoner.config import Config
 from reckoner.course import Course
 from reckoner.repository import Repository
 from reckoner.helm.client import HelmClient
+from reckoner import exception
 
 
 class TestBase(unittest.TestCase):
@@ -93,6 +94,51 @@ class TestReckonerMethods(TestBase):
         install_response = reckoner_instance.install()
         self.assertIsInstance(install_response, bool)
         self.assertTrue(install_response)
+
+
+class TestCourseMocks(unittest.TestCase):
+    @mock.patch('reckoner.course.yaml', autospec=True)
+    @mock.patch('reckoner.course.HelmClient', autospec=True)
+    def test_raises_errors_when_missing_heading(self, mock_helm, mock_yaml):
+        course_yml = {
+            'namespace': 'fake',
+            'charts': {
+                'fake-chart': {
+                    'chart': 'none',
+                    'version': 'none',
+                    'repository': 'none',
+                }
+            }
+        }
+
+        mock_yaml.load.side_effect = [course_yml]
+        helm_instance = mock_helm()
+        helm_instance.client_version = '0.0.0'
+
+        instance = reckoner.course.Course(None)
+        with self.assertRaises(exception.NoChartsToInstall):
+            instance.plot(['a-chart-that-is-not-defined'])
+
+    @mock.patch('reckoner.course.yaml', autospec=True)
+    @mock.patch('reckoner.course.HelmClient', autospec=True)
+    def test_passes_if_any_charts_exist(self, mock_helm, mock_yaml):
+        course_yml = {
+            'namespace': 'fake',
+            'charts': {
+                'fake-chart': {
+                    'chart': 'none',
+                    'version': 'none',
+                    'repository': 'none',
+                }
+            }
+        }
+
+        mock_yaml.load.side_effect = [course_yml]
+        helm_instance = mock_helm()
+        helm_instance.client_version = '0.0.0'
+
+        instance = reckoner.course.Course(None)
+        self.assertTrue(instance.plot(['a-chart-that-is-not-defined', 'fake-chart']))
 
 
 test_course = "./tests/test_course.yml"


### PR DESCRIPTION
This changes the behavior to run the hooks from the course.yml directory by default. You can still define absolute paths, but all relative paths should start from where course.yml exists. This is how I understand most implementation are today (either absolute or relative to course.yml).