### PR TITLE
Fix hook execution path

### DIFF
--- a/reckoner/config.py
+++ b/reckoner/config.py
@@ -70,10 +70,7 @@ class Config(object):
 
     @property
     def course_base_directory(self):
-        if self.course_path:
-            return dirname(self.course_path)
-        else:
-            return None
+        return dirname(self.course_path) or None
 
     def __setattr__(self, name, value):
         object.__setattr__(self, name, value)


### PR DESCRIPTION
The dirname() was returning "" empty white space which was causing subprocess to try and cd to "" dir which cannot exist. This may not have been caught if ./ was used in testing