### PR TITLE
Fixing broken hook runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.2]
+
+### Fixed
+* Fixed hook runner behavior: Previous to v1.0.0, the hooks would stop running
+  after the first non-zero exit code. This behavior broke with some refactoring
+* Added tests to catch run-hook behavior
+
 ## [1.0.1]
 
 ### Fixed

--- a/reckoner/meta.py
+++ b/reckoner/meta.py
@@ -16,5 +16,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '1.0.1'
+__version__ = '1.0.2'
 __author__ = 'ReactiveOps, Inc.'

--- a/reckoner/tests/test_course.py
+++ b/reckoner/tests/test_course.py
@@ -103,9 +103,10 @@ class TestIntegrationWithChart(unittest.TestCase):
             }
         }
 
-        chartCallMock.side_effects = [Response(exitcode=1, command_string='mocked', stderr=' ', stdout=' ')]
+        chartCallMock.return_value = Response(exitcode=1, command_string='mocked', stderr=' ', stdout=' ')
 
         course = Course(None)
         course.plot(['first-chart'])
 
+        self.assertEqual(chartCallMock.call_count, 1)
         self.assertEqual(len(course.failed_charts), 1, "We should have only one failed chart install due to hook failure.")

--- a/reckoner/tests/test_course.py
+++ b/reckoner/tests/test_course.py
@@ -14,8 +14,8 @@
 
 import mock
 import unittest
-from reckoner.exception import MinimumVersionException
 from reckoner.course import Course
+from reckoner.command_line_caller import Response
 
 
 @mock.patch('reckoner.repository.Repository', autospec=True)
@@ -73,3 +73,39 @@ class TestMinVersion(unittest.TestCase):
 
         sysMock.exit.assert_called_once
         return True
+
+
+@mock.patch('reckoner.chart.call', autospec=True)
+@mock.patch('reckoner.repository.Repository', autospec=True)
+@mock.patch('reckoner.course.sys')
+@mock.patch('reckoner.course.yaml', autospec=True)
+@mock.patch('reckoner.course.HelmClient', autospec=True)
+@mock.patch('reckoner.course.Config', autospec=True)
+class TestIntegrationWithChart(unittest.TestCase):
+    def test_failed_pre_install_hooks_fail_chart_installation(self, configMock, helmClientMock, yamlLoadMock, sysMock, repoMock, chartCallMock):
+        """Test that the chart isn't installed when the pre_install hooks return any non-zero responses. This also assures we don't raise python errors with hook errors."""
+        c = configMock()
+        c.helm_args = ['provided args']
+        c.local_development = False
+
+        h = helmClientMock()
+        h.client_version = '0.0.1'
+
+        yamlLoadMock.load.return_value = {
+            'charts': {
+                'first-chart': {
+                    'hooks': {
+                        'pre_install': [
+                            'run a failed command here',
+                        ]
+                    }
+                }
+            }
+        }
+
+        chartCallMock.side_effects = [Response(exitcode=1, command_string='mocked', stderr=' ', stdout=' ')]
+
+        course = Course(None)
+        course.plot(['first-chart'])
+
+        self.assertEqual(len(course.failed_charts), 1, "We should have only one failed chart install due to hook failure.")


### PR DESCRIPTION
Overview of the breaking change I made here.
1. I changed the contract of the call() function
   so it always returns a response even if the
   exitcode was not 0. (this was a change from before)
   The intent was so that we can run commands and decide
   what to do upstream depending on exitcode or other
   information.
2. The tests I wrote actually should have been bubbling up
   errors from the run_hook() method, since we are not
   throwing the error at call().

I have added tests to make sure we throw errors with
non-zero exit codes.