### PR TITLE
Pytest change

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
             sudo pip install .
             reckoner --version
             sudo pip install -r tests/requirements.txt
-            nose2
+            pytest
       - setup_remote_docker
       - run:
           name: Build Docker Image
@@ -84,5 +84,3 @@ workflows:
               only: /.*/
             branches:
               ignore: /.*/
-
-

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,1 +1,2 @@
 pytest
+mock

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,1 @@
-nose2==0.8.0
 pytest

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,1 +1,2 @@
 nose2==0.8.0
+pytest


### PR DESCRIPTION
Pipeline is currently broken because nose2 sometimes doesn't load the mock (WAT?)

I am going to be retagging this merge as v1.0.2 due to the problems with the pipeline currently. 

How to reproduce the error:
```
# from root directory
nose2   # This fails same as CI does
nose2 -s reckoner/tests # This passes and it runs the test that fails in the previous command
pytest # always works 
```
When debugging i could see that the mock wasn't being instantiated with nose2 when running from root. When you add a start directory to nose2, it *does* use the mock, which is super weird and inconsistent. 

I'm opting to move this all to pytest instead of figuring out why nose2 isn't working. 