### PR TITLE
Versioning Changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,20 +61,51 @@ jobs:
     environment: ~
     working_directory: ~/reckoner
     steps:
+      - run:
+          name: Setup PATH to support pip user installs
+          command: echo 'export PATH=$PATH:/home/circleci/.local/bin' >> $BASH_ENV
       - checkout
       - run:
           name: Unit Tests
           command: |
-            sudo pip install .
+            pip install --user -r development-requirements.txt
+            pip install --user -e .
             reckoner --version
-            sudo pip install -r tests/requirements.txt
             pytest
-      - setup_remote_docker
+  build-3.6:
+    docker:
+      - image: circleci/python:3.6
+    environment: ~
+    working_directory: ~/reckoner
+    steps:
       - run:
-          name: Build Docker Image
+          name: Setup PATH to support pip user installs
+          command: echo 'export PATH=$PATH:/home/circleci/.local/bin' >> $BASH_ENV
+      - checkout
+      - run:
+          name: Unit Tests
           command: |
-            docker build -t reckoner .
-            docker run --rm reckoner --version
+            pip install --user -r development-requirements.txt
+            pip install --user -e .
+            reckoner --version
+            pytest
+  build-3.7:
+    docker:
+      - image: circleci/python:3.7
+    environment: ~
+    working_directory: ~/reckoner
+    steps:
+      - run:
+          name: Setup PATH to support pip user installs
+          command: echo 'export PATH=$PATH:/home/circleci/.local/bin' >> $BASH_ENV
+      - checkout
+      - run:
+          name: Unit Tests
+          command: |
+            pip install --user -r development-requirements.txt
+            pip install --user -e .
+            reckoner --version
+            pytest
             
   release:
     docker:
@@ -92,13 +123,6 @@ jobs:
             echo -e "[pypi]" >> ~/.pypirc
             echo -e "username = $PYPI_USERNAME" >> ~/.pypirc
             echo -e "password = $PYPI_PASSWORD" >> ~/.pypirc
-      - run:
-          name: create release
-          command: |
-            echo "Using Repo:$GITHUB_REPOSITORY and Org:$GITHUB_ORGANIZATION"
-            git fetch --tags
-            curl -O https://raw.githubusercontent.com/reactiveops/release.sh/v0.0.2/release
-            /bin/bash release
       - run:
           name: package and upload
           command: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-
+.eggs
 *egg-info
 *.pyc
 venvbuild

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.1]
+
+### Changes
+- Adjusted versioning to be based on git tag
+- Added support for python 3.6 & 3.7 with CI checks
+
 ## [1.1.0]
 
 ### Changes

--- a/development-requirements.txt
+++ b/development-requirements.txt
@@ -1,2 +1,6 @@
 pytest
 pytest-cov
+wheel
+mock
+autopep8
+flake8

--- a/reckoner/tests/test_meta.py
+++ b/reckoner/tests/test_meta.py
@@ -1,7 +1,3 @@
-# -- coding: utf-8 --
-
-# pylint: skip-file
-
 # Copyright 2019 ReactiveOps Inc
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,13 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from pkg_resources import get_distribution, DistributionNotFound
-import re
 
-__version_modifier__ = re.compile(r'^([0-9]+\.[0-9]+\.[0-9]+)\.(.*)$')
-__distribution_name__ = 'reckoner'
-try:
-    __version__ = re.sub(__version_modifier__, r'\g<1>-\g<2>', get_distribution(__distribution_name__).version)
-except DistributionNotFound:
-    pass
-__author__ = 'ReactiveOps, Inc.'
+import unittest
+from reckoner.meta import __version__ as reckoner_version
+import semver
+
+
+class TestValidVersionName(unittest.TestCase):
+    """Always make sure whatever the version is will be compatible with semver parseing"""
+
+    def test_version_is_valid(self):
+        """Load the reckoner version and parse with semver"""
+        assert semver.parse_version_info(reckoner_version)

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,3 +10,6 @@ max_line_length = 160
 
 [pylama:pep8]
 max_line_length = 160
+
+[options]
+setup_requires = setuptools_scm

--- a/setup.py
+++ b/setup.py
@@ -15,12 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import sys
-
-from setuptools import setup, find_packages
-
-from reckoner.meta import __version__, __author__
+from reckoner.meta import __author__
 
 try:
     from setuptools import setup, find_packages
@@ -31,19 +27,20 @@ except ImportError:
 
 
 setup(name='reckoner',
-      version=__version__,
+      use_scm_version=True,
+      setup_requires=['setuptools_scm'],
       description='Declarative Helm configuration with Git capability',
       author=__author__,
       author_email='service@reactiveops.com',
       url='http://reactiveops.com/',
       license='Apache2.0',
-      packages=find_packages(exclude=('tests','*.tests')),
+      packages=find_packages(exclude=('tests', '*.tests')),
       install_requires=[
-        "click==6.7",
-        "GitPython==2.1.3",
-        "oyaml>=0.8",
-        "coloredlogs==9.0",
-        "semver==2.8.0"
+          "click==6.7",
+          "GitPython==2.1.3",
+          "oyaml>=0.8",
+          "coloredlogs==9.0",
+          "semver==2.8.0"
       ],
       entry_points=''' #for click integration
           [console_scripts]

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,0 @@
-pytest
-mock


### PR DESCRIPTION
Reckoner versions now can be based on git tag. This also shows users who install via source if their repo has any different changes. This has some regex that makes the version more compatible with semver module for comparisons.

Main Benefits
- When developing / installing locally you can see if you've installed from a dirty branch or are ahead of a released version
- You now do releases by just tagging the git repo and pushing the tag, no more managing meta.py for `__version__`