### PR TITLE
Fixing interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.2]
+
+### Changes
+- Added fix for interpolated variables in kube specs (see #82)
+
 ## [1.1.1]
 
 ### Changes

--- a/reckoner/chart.py
+++ b/reckoner/chart.py
@@ -397,8 +397,8 @@ class Chart(object):
         """
         if self._hack_set_values_already_merged:
             raise Exception('This method cannot be called twice. '
-                                'If you are seeing this please open an '
-                                'issue in github.')
+                            'If you are seeing this please open an '
+                            'issue in github.')
 
         def merge_dicts(values, sets):
             """This does a dict merge and prefers "sets" values"""
@@ -426,7 +426,12 @@ class Chart(object):
         and are missing from the environment
         an exception is raised
         """
-        try:
-            self.args = [Template(arg).substitute(os.environ) for arg in self.args]
-        except KeyError as e:
-            raise Exception("Missing requirement environment variable: {}".format(e.args[0]))
+        for idx in range(len(self.args)):
+            try:
+                self.args[idx] = Template(self.args[idx]).substitute(os.environ)
+            except ValueError:
+                logging.debug("Could not replace Variable {} with an Env Var: Formatting Error.".format(self.args[idx]))
+                logging.debug("This generally happens if you use $(THING) instead of $THING or ${THING}.")
+                continue
+            except KeyError:
+                raise Exception("Missing requirement environment variable: {}".format(self.args[idx]))


### PR DESCRIPTION
Fixing issues with #82 

Allows you to define specs that may have `$(VAR)` in the definition. Previous behavior would send a stacktrace to the user. 

See [this link](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/#using-environment-variables-inside-of-your-config) for usage example.