### PR TITLE
Added dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -302,6 +302,7 @@ workflows:
       - end-to-end:
           requires:
             - compile
+            - compile-darwin
           filters:
             tags:
               only: /.*/


### PR DESCRIPTION
Apparently there has to be a relationship all the way downstream for any workspaces. Even though we're building and uploading the darwin build earlier in the jobs, it doesn't show up as accessible to the last "publish-binaries" job since it doesn't have a technical inheritance. 