### PR TITLE
Deprecating Python2 and requiring ~=3.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,9 +15,6 @@
 version: 2.1
 
 executors:
-  python-2-7:
-    docker:
-      - image: circleci/python:2.7
   python-3-6:
     docker:
       - image: circleci/python:3.6
@@ -32,22 +29,6 @@ executors:
       xcode: 10.2.0
 
 jobs:
-  build-2-7:
-    executor: python-2-7
-    working_directory: ~/reckoner
-    steps:
-      - run:
-          name: Setup PATH to support pip user installs
-          command: echo 'export PATH=$PATH:/home/circleci/.local/bin' >> $BASH_ENV
-      - checkout
-      - run:
-          name: Unit Tests
-          command: |
-            pip install --user -r development-requirements.txt
-            pip install --user -e .
-            reckoner --version
-            pytest --cov ./
-            codecov
   build-3-6:
     executor: python-3-6
     working_directory: ~/reckoner
@@ -62,8 +43,7 @@ jobs:
             pip install --user -r development-requirements.txt
             pip install --user -e .
             reckoner --version
-            pytest --cov ./
-            codecov
+            pytest
   build-3-7:
     executor: python-3-7
     working_directory: ~/reckoner
@@ -265,12 +245,6 @@ workflows:
   version: 2
   build:
     jobs:
-      - build-2-7:
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              only: /.*/
       - build-3-6:
           filters:
             tags:
@@ -285,7 +259,6 @@ workflows:
               only: /.*/
       - compile-darwin:
           requires:
-            - build-2-7
             - build-3-6
             - build-3-7
           filters:
@@ -295,7 +268,6 @@ workflows:
               only: /.*/
       - compile:
           requires:
-            - build-2-7
             - build-3-6
             - build-3-7
           filters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.3.0]
+### Breaking Changes
+Python2 support is now ended.  Pip install will now require python ~= 3.6.  In any case, use of the binary release is recommended.
+
 ## [1.2.0]
 - Support helm wrapper plugins such as [Helm Secrets](https://github.com/futuresimple/helm-secrets)
 - POTENTIAL BREAKING CHANGE: Refactored all helm commands to use `--arg value` instead of `--arg=value`. (This helps with poor param support with how helm plugin wrappers work)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,8 @@ Requirements
 ```
 Note that some of the above commands may need `python3` instead of just `python` to work depending on your environment.
 
+*Note:* Python2 is no longer supported by this tool
+
 ## Requirements for Pull Requests
 * Update the changelog
 * Run tests

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-
-# reckoner [![CircleCI](https://circleci.com/gh/reactiveops/reckoner.svg?style=svg)](https://circleci.com/gh/reactiveops/reckoner)
+# reckoner [![CircleCI](https://circleci.com/gh/reactiveops/reckoner.svg?style=svg)](https://circleci.com/gh/reactiveops/reckoner) [![codecov](https://codecov.io/gh/reactiveops/reckoner/branch/master/graph/badge.svg)](https://codecov.io/gh/reactiveops/reckoner)
 
 Command line helper for helm.
 This utility adds to the functionality of [Helm](https://github.com/kubernetes/helm) in multiple ways:
@@ -11,6 +10,8 @@ This utility adds to the functionality of [Helm](https://github.com/kubernetes/h
 ## Requirements
 - python 3
 - helm: installed and initialized
+
+*Note:* Python2 is no longer supported by Reckoner. In general we suggest using the binary on the [Releases](https://github.com/reactiveops/reckoner/releases) page.
 
 ### Installation
 Via Binary: *preferred method*
@@ -51,12 +52,6 @@ For development see [CONTRIBUTING.md](./CONTRIBUTING.md).
       * `--local-development`: Run `reckoner` in local-development mode where Tiller is not required and no helm commands are run. Useful for rapid or offline development.
   * `generate`: Generates example file `course.yml` with extensive descriptions
   * `version`: Output reckoner version
-
-## Example configuration file:
-
-There is an example file in reckoner/example-course.yml
-
-Further customization is documented below.
 
 # Options
 

--- a/reckoner/command_line_caller/tests/test_command_line_caller.py
+++ b/reckoner/command_line_caller/tests/test_command_line_caller.py
@@ -14,6 +14,7 @@
 
 import unittest
 from reckoner.command_line_caller import Response
+from reckoner.command_line_caller import call
 
 
 class TestResponse(unittest.TestCase):
@@ -34,3 +35,25 @@ class TestResponse(unittest.TestCase):
 
         response = Response('', '', 0, '')
         self.assertTrue(response, "All responses with exitcode 0 should return True")
+
+    def test_support_comparisons(self):
+        resp_one = Response('', '', 0, '')
+        resp_two = Response('', '', 0, '')
+        resp_three = Response('', '', 0, 'notequal')
+
+        self.assertEqual(resp_one, resp_two)
+        self.assertNotEqual(resp_one, resp_three)
+        self.assertNotEqual(resp_two, resp_three)
+
+    def test_support_str(self):
+        resp = Response('', '', 0, '')
+        self.assertEqual(resp.__str__(), "{'stdout': '', 'stderr': '', 'exitcode': 0, 'command_string': ''}")
+
+
+class TestCall(unittest.TestCase):
+    def test_call_command(self):
+        """Call whoami and expect an output"""
+        p = call('whoami', shell=False, executable=None, path=None)
+        self.assertIsInstance(p, Response)
+        self.assertIsInstance(p.stdout, str)
+        self.assertIsInstance(p.stderr, str)

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ except ImportError:
 
 
 setup(name='reckoner',
+      python_requires='~=3.6',
       use_scm_version=True,
       setup_requires=['setuptools_scm'],
       description='Declarative Helm configuration with Git capability',


### PR DESCRIPTION
This removes the ability to install Reckoner in a python2 environment. There are notes in both the README and CONTRIBUTING docs, as well as disabling python2 in the setup.py.  CI for python2 has also been removed.

Example output when trying to pip install in python2:

```
 reactiveops/reckoner   sudermanjr/deprecate-python-2 ✘   .venv-2 
└─ pip install .
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.
Processing /Users/asuderma/repos/reactiveops/reckoner
ERROR: reckoner requires Python '~=3.6' but the running Python is 2.7.15
```

Setup.py changes based on docs here: https://packaging.python.org/guides/distributing-packages-using-setuptools/

Also in this PR:
* Adding codecov badge.
* Removed call to codecov on python 3.6 build.  Only need to run codecov
script once.